### PR TITLE
Fix suhosin detection with no whitelist set

### DIFF
--- a/installer
+++ b/installer
@@ -75,14 +75,8 @@ function checkPlatform()
     }
 
     $suhosin = ini_get('suhosin.executor.include.whitelist');
-    if ($suhosin !== false) {
-        if ($suhosin == "") {
-            // Suhosin enabled, but whitelist not set
-            $errors['suhosin'] = $suhosin;
-        } elseif (false === stripos($suhosin, 'phar')) {
-            // Suhosin enabled, but phar not in whitelist
-            $errors['suhosin'] = $suhosin;
-        }
+    if (false !== $suhosin && false === stripos($suhosin, 'phar')) {
+        $errors['suhosin'] = $suhosin;
     }
 
     if (PHP_VERSION < '5.3.2') {


### PR DESCRIPTION
Fix suhosin detection when no whitelist is set and suhosin is enabled, the installer also displays the suhosin error message

Fix for https://github.com/composer/composer/issues/259

Checked with 
Installs - suhosin disabled 
Installs - suhosin enabled and suhosin.executor.include.whitelist = phar 
Error message - suhosin enabled, and suhosin.executor.include.whitelist not set 
Error message - suhosin enabled and suhosin.executor.include.whitelist = 
