### PR TITLE
fixed installer choking on empty HTTP_PROXY environment variable

### DIFF
--- a/web/installer
+++ b/web/installer
@@ -287,9 +287,9 @@ function getStreamContext()
     $options = array('http' => array());
 
     // Handle system proxy
-    if (isset($_SERVER['HTTP_PROXY']) || isset($_SERVER['http_proxy'])) {
+    if (!empty($_SERVER['HTTP_PROXY']) || !empty($_SERVER['http_proxy'])) {
         // Some systems seem to rely on a lowercased version instead...
-        $proxy = parse_url(isset($_SERVER['http_proxy']) ? $_SERVER['http_proxy'] : $_SERVER['HTTP_PROXY']);
+        $proxy = parse_url(!empty($_SERVER['http_proxy']) ? $_SERVER['http_proxy'] : $_SERVER['HTTP_PROXY']);
     }
 
     if (!empty($proxy)) {


### PR DESCRIPTION
Signed-off-by: WanWizard wanwizard@wanwizard.eu
