### PR TITLE
Update installer error messages to include PHP.INI path.

### DIFF
--- a/web/installer
+++ b/web/installer
@@ -83,10 +83,11 @@ function checkPlatform($quiet)
     $errors = array();
     $warnings = array();
     $inipath = php_ini_loaded_file();
+    $displayIniMessage = false;
     if ($inipath) {
-        $ini_message = 'Loaded php.ini: ' . $inipath;
+        $iniMessage = 'Loaded php.ini: ' . $inipath;
     } else {
-        $ini_message = "A php.ini file doesn't exist.  Please create one.";
+        $iniMessage = "A php.ini file doesn't exist.  Please create one.";
     }
 
     if (ini_get('detect_unicode')) {
@@ -152,14 +153,14 @@ function checkPlatform($quiet)
                     $text = PHP_EOL."The detect_unicode setting must be disabled.".PHP_EOL;
                     $text .= "Add the following to the end of your `php.ini`:".PHP_EOL;
                     $text .= "    detect_unicode = Off".PHP_EOL;
-                    $text .= $ini_message;
+                    $displayIniMessage = true;
                     break;
 
                 case 'suhosin':
                     $text = PHP_EOL."The suhosin.executor.include.whitelist setting is incorrect.".PHP_EOL;
                     $text .= "Add the following to the end of your `php.ini` or suhosin.ini (Example path [for Debian]: /etc/php5/cli/conf.d/suhosin.ini):".PHP_EOL;
                     $text .= "    suhosin.executor.include.whitelist = phar ".$current.PHP_EOL;
-                    $text .= $ini_message;
+                    $displayIniMessage = true;
                     break;
 
                 case 'php':
@@ -170,15 +171,18 @@ function checkPlatform($quiet)
                     $text = PHP_EOL."The allow_url_fopen setting is incorrect.".PHP_EOL;
                     $text .= "Add the following to the end of your `php.ini`:".PHP_EOL;
                     $text .= "    allow_url_fopen = On".PHP_EOL;
-                    $text .= $ini_message;
+                    $displayIniMessage = true;
                     break;
 
                 case 'ioncube':
                     $text = PHP_EOL."The ionCube Loader extension is incompatible with Phar files.".PHP_EOL;
                     $text .= "Remove this line (path may be different) from your `php.ini`:".PHP_EOL;
                     $text .= "    zend_extension = /usr/lib/php5/20090626+lfs/ioncube_loader_lin_5.3.so".PHP_EOL;
-                    $text .= $ini_message;
+                    $displayIniMessage = true;
                     break;
+            }
+            if ($displayIniMessage) {
+                $text .= $iniMessage;
             }
             out($text, 'info');
         }
@@ -197,7 +201,7 @@ function checkPlatform($quiet)
                     $text = PHP_EOL."The apc.enable_cli setting is incorrect.".PHP_EOL;
                     $text .= "Add the following to the end of your `php.ini`:".PHP_EOL;
                     $text .= "    apc.enable_cli = Off".PHP_EOL;
-                    $text .= $ini_message;
+                    $displayIniMessage = true;
                     break;
 
                 case 'sigchild':
@@ -211,13 +215,16 @@ function checkPlatform($quiet)
                     $text .= "Add the following to the end of your `php.ini`:".PHP_EOL;
                     $text .= "    ; UTC here is an example, use your own timezone, see http://www.php.net/manual/en/timezones.php".PHP_EOL;
                     $text .= "    date.timezone = UTC".PHP_EOL;
-                    $text .= $ini_message;
+                    $displayIniMessage = true;
                     break;
 
                 case 'php':
                     $text = PHP_EOL."Your PHP ({$current}) is quite old, upgrading to PHP 5.3.4 or higher is recommended.".PHP_EOL;
                     $text .= "Composer works with 5.3.2+ for most people, but there might be edge case issues.";
                     break;
+            }
+            if ($displayIniMessage) {
+                $text .= $iniMessage;
             }
             out($text, 'info');
         }


### PR DESCRIPTION
For instance:

$ curl -s http://getcomposer.org/installer | php
# !/usr/bin/env php

Some settings on your machine make Composer unable to work properly.
Make sure that you fix the issues listed below and run this script again:

The detect_unicode setting must be disabled.
Add the following to the end of your php.ini: detect_unicode = Off

You config file can be found here:
/etc/php.ini.default
