### PR TITLE
command "curl -s https://getcomposer.org/installer | php" didn't work with HTTP_PROXY on RH ES.

### DIFF
--- a/web/installer
+++ b/web/installer
@@ -272,9 +272,16 @@ function installComposer($installDir, $quiet)
         $source = (extension_loaded('openssl') ? 'https' : 'http').'://getcomposer.org/composer.phar';
         $errorHandler = new ErrorHandler();
         set_error_handler(array($errorHandler, 'handleError'));
-        if (!copy($source, $file, getStreamContext())) {
-            out('Download failed: '.$errorHandler->message, 'error');
+
+        $fh = fopen($file, 'w');
+        if (!$fh) {
+            out('Create file $file failed: '.$errorHandler->message, 'error');
         }
+        if (!fwrite($fh, file_get_contents($source, false, getStreamContext()))) {
+            out('Copy data to file $file failed: '.$errorHandler->message, 'error');
+        }
+        fclose($fh);
+                                        
         restore_error_handler();
         if ($errorHandler->message) {
             continue;


### PR DESCRIPTION
On a Red Hat Enterprise Linux Server we use this variable 

HTTP_PROXY=http://www-proxy.nl.blabla.com:8080

Then I try to install composer

curl -s https://getcomposer.org/installer | php

And got this message:

Downloading...
Download failed: php_network_getaddresses: getaddrinfo failed: Name or service not known
failed to open stream: php_network_getaddresses: getaddrinfo failed: Name or service not known

The problem was/is on line 275 of the installer. 
