### PR TITLE
Installer using colors when it shouldn't

### DIFF
--- a/web/installer
+++ b/web/installer
@@ -24,6 +24,21 @@ function process($argv)
     $quiet      = in_array('--quiet', $argv);
     $installDir = false;
 
+    // --no-ansi wins over --ansi
+    if (in_array('--no-ansi', $argv)) {
+        define('USE_ANSI', false);
+    } elseif (in_array('--ansi', $argv)) {
+        define('USE_ANSI', true);
+    } else {
+        // On Windows, default to no ANSI, except in ANSICON.
+        // Everywhere else, default to ANSI if stdout is a terminal.
+        define('USE_ANSI',
+            (DIRECTORY_SEPARATOR == '\\')
+                ? (false !== getenv('ANSICON'))
+                : (posix_isatty(1))
+        );
+    }
+
     foreach ($argv as $key => $val) {
         if (0 === strpos($val, '--install-dir')) {
             if (13 === strlen($val) && isset($argv[$key+1])) {
@@ -70,6 +85,8 @@ Options
 --help               this help
 --check              for checking environment only
 --force              forces the installation
+--ansi               force ANSI color output
+--no-ansi            disable ANSI color output
 --install-dir="..."  accepts a target installation directory
 
 EOF;
@@ -336,12 +353,6 @@ function installComposer($installDir, $quiet)
  */
 function out($text, $color = null, $newLine = true)
 {
-    if (DIRECTORY_SEPARATOR == '\\') {
-        $hasColorSupport = false !== getenv('ANSICON');
-    } else {
-        $hasColorSupport = true;
-    }
-
     $styles = array(
         'success' => "\033[0;32m%s\033[0m",
         'error' => "\033[31;31m%s\033[0m",
@@ -350,7 +361,7 @@ function out($text, $color = null, $newLine = true)
 
     $format = '%s';
 
-    if (isset($styles[$color]) && $hasColorSupport) {
+    if (isset($styles[$color]) && USE_ANSI) {
         $format = $styles[$color];
     }
 


### PR DESCRIPTION
Currently, the `out()` function of the Composer installer checks whether it's on Windows and if not, ANSI escape codes will be output.

This looks nice on a Unix terminal, but I for example run the installer from a Jenkins job, and the console output will be displayed in my browser, with raw ANSI codes all over the place. It would be nice if the installer was a bit smarter when deciding whether to use colors or not, or at least let the user specify their preference.

My suggestion is to
1. introduce the parameters `--ansi` and `--no-ansi` to force-enable or -disable ANSI output and
2. (optionally) if the machine is not using Windows and neither of the new ANSI parameters is used, use PHP's `posix_isatty()` to decide whether stdout is a terminal and default to using colors only then.

If you agree that these changes would be nice, I can implement that and send you a pull request.
