### PR TITLE
installer supports --filename

### DIFF
--- a/views/download.html.twig
+++ b/views/download.html.twig
@@ -9,8 +9,8 @@
     <p>This installer script will simply check some php.ini settings, warn you if they are set incorrectly, and then download the latest composer.phar in the current directory</p>
 
     <h2>Installer Options</h2>
-    <p>You can install composer to a specific directory by using the <code>--install-dir</code> option and providing a target directory. Options must be appended to <code>--</code> so that PHP ignores them, like <code>-- --install-dir=bin</code>, example:</p>
-    <code>curl -sS https://getcomposer.org/installer | php -- --install-dir=bin</code>
+    <p>You can install composer to a specific directory by using the <code>--install-dir</code> option and providing a target directory. You can specify the filename (default: composer.phar) using the <code>--filename</code> option, e.g. <code>--filename=composer</code>. Options must be appended to <code>--</code> so that PHP ignores them, like <code>-- --install-dir=bin</code>, example:</p>
+    <code>curl -sS https://getcomposer.org/installer | php -- --install-dir=bin --filename=composer</code>
 
     {% if windows %}
         <h2>Windows Installer</h2>

--- a/web/installer
+++ b/web/installer
@@ -23,6 +23,7 @@ function process($argv)
     $force      = in_array('--force', $argv);
     $quiet      = in_array('--quiet', $argv);
     $installDir = false;
+    $filename   = 'composer.phar';
 
     // --no-ansi wins over --ansi
     if (in_array('--no-ansi', $argv)) {
@@ -47,6 +48,13 @@ function process($argv)
                 $installDir = trim(substr($val, 14));
             }
         }
+        if (0 === strpos($val, '--filename')) {
+            if (10 === strlen($val) && isset($argv[$key+1])) {
+                $filename = trim($argv[$key+1]);
+            } else {
+                $filename = trim(substr($val, 11));
+            }
+        }
     }
 
     if ($help) {
@@ -66,7 +74,7 @@ function process($argv)
     }
 
     if ($ok || $force) {
-        installComposer($installDir, $quiet);
+        installComposer($installDir, $filename, $quiet);
         exit(0);
     }
 
@@ -88,6 +96,7 @@ Options
 --ansi               force ANSI color output
 --no-ansi            disable ANSI color output
 --install-dir="..."  accepts a target installation directory
+--filename="..."     accepts a target filename (default: composer.phar)
 
 EOF;
 }
@@ -306,11 +315,11 @@ function checkPlatform($quiet)
 /**
  * installs composer to the current working directory
  */
-function installComposer($installDir, $quiet)
+function installComposer($installDir, $filename, $quiet)
 {
-    $installPath = (is_dir($installDir) ? rtrim($installDir, '/').'/' : '') . 'composer.phar';
+    $installPath = (is_dir($installDir) ? rtrim($installDir, '/').'/' : '') . $filename;
     $installDir = realpath($installDir) ? realpath($installDir) : getcwd();
-    $file       = $installDir.DIRECTORY_SEPARATOR.'composer.phar';
+    $file       = $installDir.DIRECTORY_SEPARATOR.$filename;
 
     if (is_readable($file)) {
         @unlink($file);


### PR DESCRIPTION
In addition to the existing `--install-dir`, installer accepts `--filename`
which, for example, allows Composer to be installed as `composer` instead of
`composer.phar`.

Example:

```
curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
```
