### PR TITLE
compile PHAR from folder without dev dependencies

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -21,7 +21,7 @@ git fetch -q origin && \
 git fetch --tags -q origin && \
 git checkout master -q && \
 git rebase origin/master -q && \
-$composer install -q && \
+$composer install -q --no-dev && \
 php -d phar.readonly=0 $buildscript && \
 mv $buildphar "$root/$target/$buildphar" && \
 git log --pretty="%H" -n1 HEAD > "$root/$target/version"
@@ -32,7 +32,7 @@ for version in `git tag`; do
     then
         mkdir -p "$root/$target/download/$version/"
         git checkout $version -q && \
-        $composer install -q && \
+        $composer install -q --no-dev && \
         php -d phar.readonly=0 $buildscript && \
         touch --date="`git log -n1 --pretty=%ci $version`" $buildphar && \
         mv $buildphar "$root/$target/download/$version/$buildphar"


### PR DESCRIPTION
Currently "composer.phar" ships a autoloading classmap for PHPUnit.
that's because composer's own development dependencies are installed (composer install -q) and autoloading maps are created. The PHAR compiler excludes "Tests" folders and PHPUnit itself from vendor folders, but includes the autoloading maps.

By appending "--no-dev" PHPUnit is not installed and an empty map is created.
This empty map is then included by the PHAR compiler.
So this change reduced the size of the PHAR.

And this leads directly to the next issue: "exclude empty autloading map files from inclusion into a PHAR". Including empty autoloading strategies is waste. But that's a PHAR compiler issue.
