### PR TITLE
fixed warnings expects parameter 2 to be array, refs #82

### DIFF
--- a/web/installer
+++ b/web/installer
@@ -11,7 +11,7 @@
  * file that was distributed with this source code.
  */
 
-process($argv);
+process( is_array($argv) ? $argv : array() );
 
 /**
  * processes the installer


### PR DESCRIPTION
fixed warnings expects parameter 2 to be array, refs #82
suggested by stof: IMO, it would be better to always pass an array to the process method, fixing the calling code