### PR TITLE
Add the page name to the title when viewing documentation.

### DIFF
--- a/src/controllers.php
+++ b/src/controllers.php
@@ -147,6 +147,7 @@ $app->get('/doc/{page}', function ($page) use ($app) {
     };
 
     // build TOC & deep links
+    $firstTitle = null;
     $h1 = $h2 = $h3 = $h4 = 0;
     $nodes = $xpath->query('//*[self::h1 or self::h2 or self::h3 or self::h4]');
     foreach ($nodes as $node) {
@@ -162,6 +163,10 @@ $app->get('/doc/{page}', function ($page) use ($app) {
         $link->setAttribute('href', '#'.$id);
         $link->setAttribute('class', 'anchor');
         $node->appendChild($link);
+
+        if (!isset($first_title) && strlen($title) > 0) {
+            $first_title = $title;
+        }
 
         // parse into a tree
         switch ($node->nodeName) {
@@ -195,6 +200,7 @@ $app->get('/doc/{page}', function ($page) use ($app) {
         'file' => $page,
         'page' => $page == '00-intro.md' ? 'getting-started' : 'docs',
         'toc' => $toc,
+        'title' => $first_title
     ));
 })
 ->assert('page', '[a-z0-9/\'-]+\.md')

--- a/src/controllers.php
+++ b/src/controllers.php
@@ -164,8 +164,8 @@ $app->get('/doc/{page}', function ($page) use ($app) {
         $link->setAttribute('class', 'anchor');
         $node->appendChild($link);
 
-        if (!isset($first_title) && strlen($title) > 0) {
-            $first_title = $title;
+        if (empty($firstTitle)) {
+            $firstTitle = $title;
         }
 
         // parse into a tree
@@ -200,7 +200,7 @@ $app->get('/doc/{page}', function ($page) use ($app) {
         'file' => $page,
         'page' => $page == '00-intro.md' ? 'getting-started' : 'docs',
         'toc' => $toc,
-        'title' => $first_title
+        'title' => $firstTitle
     ));
 })
 ->assert('page', '[a-z0-9/\'-]+\.md')

--- a/views/doc.show.html.twig
+++ b/views/doc.show.html.twig
@@ -1,5 +1,7 @@
 {% extends "layout.html.twig" %}
 
+{% block title %}Composer{% if title|length %} - {{ title }}{% endif %}{% endblock %}
+
 {% block content %}
     {% if toc|length %}
         <ul class="toc">


### PR DESCRIPTION
When viewing the documentation, grab the first heading of the page, and set that to be appended to the title of the page.

Google is smart enough to rewrite the page title:

![screen shot 2015-06-17 at 11 04 55 am](https://cloud.githubusercontent.com/assets/1050232/8197804/b5202af6-14e0-11e5-8362-9f47d67f4ffd.png)

However some other search engines are not:

![screen shot 2015-06-17 at 11 04 31 am](https://cloud.githubusercontent.com/assets/1050232/8197801/a720016a-14e0-11e5-8961-c9eaa1f3a5dd.png)

