### PR TITLE
Fixed an error in the installer on older systems

### DIFF
--- a/web/installer
+++ b/web/installer
@@ -847,7 +847,7 @@ class HttpClient {
 
     public static function getPackagedCaFile()
     {
-        return <<<'CACERT'
+        return <<<CACERT
 ##
 ## ca-bundle.crt -- Bundle of CA Root Certificates
 ##


### PR DESCRIPTION
Replaced <<<'CACERT' with the more standard <<<CACERT  in the installer

On my one system I was getting this error in logs:
PHP Parse error: syntax error, unexpected T_SL on line 850

The above change fixs it so it can run.