### PR TITLE
Modifications for windows-setup

### DIFF
--- a/web/installer
+++ b/web/installer
@@ -13,111 +13,60 @@
 process(is_array($argv) ? $argv : array());
 
 /**
- * processes the installer
- */
+*  The main process function
+*
+* @param array $argv
+*/
 function process($argv)
 {
-    $check      = in_array('--check', $argv);
-    $help       = in_array('--help', $argv);
-    $force      = in_array('--force', $argv);
-    $quiet      = in_array('--quiet', $argv);
-    $channel    = in_array('--snapshot', $argv) ? 'snapshot' : (in_array('--preview', $argv) ? 'preview' : 'stable');
-    $disableTls = in_array('--disable-tls', $argv);
-    $installDir = false;
-    $version    = false;
-    $filename   = 'composer.phar';
-    $cafile     = false;
+    // Determine ANSI output from --ansi and --no-ansi flags
+    setUseAnsi($argv);
 
-    // --no-ansi wins over --ansi
-    if (in_array('--no-ansi', $argv)) {
-        define('USE_ANSI', false);
-    } elseif (in_array('--ansi', $argv)) {
-        define('USE_ANSI', true);
-    } else {
-        // On Windows, default to no ANSI, except in ANSICON and ConEmu.
-        // Everywhere else, default to ANSI if stdout is a terminal.
-        define('USE_ANSI',
-            (DIRECTORY_SEPARATOR == '\\')
-                ? (false !== getenv('ANSICON') || 'ON' === getenv('ConEmuANSI'))
-                : (function_exists('posix_isatty') && posix_isatty(1))
-        );
-    }
-
-    foreach ($argv as $key => $val) {
-        if (0 === strpos($val, '--install-dir')) {
-            if (13 === strlen($val) && isset($argv[$key+1])) {
-                $installDir = trim($argv[$key+1]);
-            } else {
-                $installDir = trim(substr($val, 14));
-            }
-        }
-
-        if (0 === strpos($val, '--version')) {
-            if (9 === strlen($val) && isset($argv[$key+1])) {
-                $version = trim($argv[$key+1]);
-            } else {
-                $version = trim(substr($val, 10));
-            }
-        }
-
-        if (0 === strpos($val, '--filename')) {
-            if (10 === strlen($val) && isset($argv[$key+1])) {
-                $filename = trim($argv[$key+1]);
-            } else {
-                $filename = trim(substr($val, 11));
-            }
-        }
-
-        if (0 === strpos($val, '--cafile')) {
-            if (8 === strlen($val) && isset($argv[$key+1])) {
-                $cafile = trim($argv[$key+1]);
-            } else {
-                $cafile = trim(substr($val, 9));
-            }
-        }
-    }
-
-    if ($help) {
+    if (in_array('--help', $argv)) {
         displayHelp();
         exit(0);
     }
 
-    $ok = checkPlatform($quiet, $disableTls);
+    $check      = in_array('--check', $argv);
+    $force      = in_array('--force', $argv);
+    $quiet      = in_array('--quiet', $argv);
+    $channel    = in_array('--snapshot', $argv) ? 'snapshot' : (in_array('--preview', $argv) ? 'preview' : 'stable');
+    $disableTls = in_array('--disable-tls', $argv);
+    $installDir = getOptValue('--install-dir', $argv, false);
+    $version    = getOptValue('--version', $argv, false);
+    $filename   = getOptValue('--filename', $argv, 'composer.phar');
+    $cafile     = getOptValue('--cafile', $argv, false);
 
-    if (false !== $installDir && !is_dir($installDir)) {
-        out("The defined install dir ({$installDir}) does not exist.", 'info');
-        $ok = false;
+    if (!checkParams($installDir, $version, $cafile)) {
+        exit(1);
     }
 
-    if (false !== $version && 1 !== preg_match('/^\d+\.\d+\.\d+(\-(alpha|beta)\d+)*$/', $version)) {
-        out("The defined install version ({$version}) does not match release pattern.", 'info');
-        $ok = false;
-    }
-
-    if (false !== $cafile && (!file_exists($cafile) || !is_readable($cafile))) {
-        out("The defined Certificate Authority (CA) cert file ({$cafile}) does not exist or is not readable.", 'info');
-        $ok = false;
-    }
-
-    if (true === $disableTls) {
-        out("You have instructed the Installer not to enforce SSL/TLS security on remote HTTPS requests.", 'info');
-        out("This will leave all downloads during installation vulnerable to Man-In-The-Middle (MITM) attacks.", 'info');
-    }
+    $warnings = array();
+    $ok = checkPlatform($warnings, $quiet, $disableTls);
 
     if ($check) {
+        // Only show warnings if we haven't output any errors
+        if ($ok) {
+            showWarnings($warnings);
+            showSecurityWarning($disableTls);
+        }
         exit($ok ? 0 : 1);
     }
 
     if ($ok || $force) {
-        installComposer($version, $installDir, $filename, $quiet, $disableTls, $cafile, $channel);
-        exit(0);
+        $installer = new Installer($quiet, $disableTls, $cafile);
+        if ($installer->run($version, $installDir, $filename, $channel)) {
+            showWarnings($warnings);
+            showSecurityWarning($disableTls);
+            exit(0);
+        }
     }
 
     exit(1);
 }
 
 /**
- * displays the help
+ * Displays the help
  */
 function displayHelp()
 {
@@ -131,94 +80,323 @@ Options
 --ansi               force ANSI color output
 --no-ansi            disable ANSI color output
 --quiet              do not output unimportant messages
+--disable-tls        disable SSL/TLS security for file downloads
 --install-dir="..."  accepts a target installation directory
 --preview            install the latest version from the preview (alpha/beta/rc) channel instead of stable
 --snapshot           install the latest version from the snapshot (dev builds) channel instead of stable
---version="..."      accepts a specific version to install instead of the latest
+--version="..."      accepts a specific version to install instead of stable
 --filename="..."     accepts a target filename (default: composer.phar)
---disable-tls        disable SSL/TLS security for file downloads
 --cafile="..."       accepts a path to a Certificate Authority (CA) certificate file for SSL/TLS verification
 
 EOF;
 }
 
 /**
- * check the platform for possible issues on running composer
- */
-function checkPlatform($quiet, $disableTls)
+* Returns the value of a command-line option
+*
+* @param string $opt The command-line option to check
+* @param array $argv Command-line arguments
+* @param mixed $default Default value to be returned
+*
+* @return mixed The command-line value or the default
+*/
+function getOptValue($opt, $argv, $default)
+{
+    $optLength = strlen($opt);
+
+    foreach ($argv as $key => $value) {
+        $next = $key + 1;
+        if (0 === strpos($value, $opt)) {
+            if ($optLength === strlen($value) && isset($argv[$next])) {
+                return trim($argv[$next]);
+            } else {
+                return trim(substr($value, $optLength + 1));
+            }
+        }
+    }
+
+    return $default;
+}
+
+/**
+* Sets the USE_ANSI constant for colorizing output
+*
+* @param array $argv Command-line arguments
+*/
+function setUseAnsi($argv)
+{
+    // --no-ansi wins over --ansi
+    if (in_array('--no-ansi', $argv)) {
+        define('USE_ANSI', false);
+    } elseif (in_array('--ansi', $argv)) {
+        define('USE_ANSI', true);
+    } else {
+        // On Windows, default to no ANSI, except in ANSICON and ConEmu.
+        // Everywhere else, default to ANSI if stdout is a terminal.
+        define(
+            'USE_ANSI',
+            (DIRECTORY_SEPARATOR == '\\')
+                ? (false !== getenv('ANSICON') || 'ON' === getenv('ConEmuANSI'))
+                : (function_exists('posix_isatty') && posix_isatty(1))
+        );
+    }
+}
+
+/**
+* Checks the platform for possible issues running Composer
+*
+* Errors are written to the output, warnings are saved for later display.
+*
+* @param array $warnings Populated by method, to be shown later
+* @param bool $quiet Quiet mode
+* @param bool $disableTls Bypass tls
+*
+* @return bool True if there are no errors
+*/
+function checkPlatform(&$warnings, $quiet, $disableTls)
+{
+    getPlatformIssues($errors, $warnings);
+
+    // Make openssl warning an error if tls has not been specifically disabled
+    if (isset($warnings['openssl']) && !$disableTls) {
+        $errors['openssl'] = $warnings['openssl'];
+        unset($warnings['openssl']);
+    }
+
+    if (!empty($errors)) {
+        out('Some settings on your machine make Composer unable to work properly.', 'error');
+        out('Make sure that you fix the issues listed below and run this script again:', 'error');
+        outputIssues($errors);
+        return false;
+    }
+
+    if (empty($warnings) && !$quiet) {
+        out('All settings correct for using Composer', 'success');
+    }
+    return true;
+}
+
+/**
+* Checks that user-supplied params are valid
+*
+* @param mixed $installDir The required istallation directory
+* @param mixed $version The required composer version to install
+* @param mixed $cafile Certificate Authority file
+*
+* @return bool True if the supplied params are okay
+*/
+function checkParams($installDir, $version, $cafile)
+{
+    $result = true;
+
+    if (false !== $installDir && !is_dir($installDir)) {
+        out("The defined install dir ({$installDir}) does not exist.", 'info');
+        $result = false;
+    }
+
+    if (false !== $version && 1 !== preg_match('/^\d+\.\d+\.\d+(\-(alpha|beta)\d+)*$/', $version)) {
+        out("The defined install version ({$version}) does not match release pattern.", 'info');
+        $result = false;
+    }
+
+    if (false !== $cafile && (!file_exists($cafile) || !is_readable($cafile))) {
+        out("The defined Certificate Authority (CA) cert file ({$cafile}) does not exist or is not readable.", 'info');
+        $result = false;
+    }
+    return $result;
+}
+
+/**
+* Outputs any warnings found
+*
+* @param array $warnings
+*/
+function showWarnings($warnings)
+{
+    if (!empty($warnings)) {
+        out('Some settings on your machine may cause stability issues with Composer.', 'error');
+        out('If you encounter issues, try to change the following:', 'error');
+        outputIssues($warnings);
+    }
+}
+
+/**
+* Outputs an end of process warning if tls has been bypassed
+*
+* @param bool $disableTls Bypass tls
+*/
+function showSecurityWarning($disableTls)
+{
+    if ($disableTls) {
+        out('You have instructed the Installer not to enforce SSL/TLS security on remote HTTPS requests.', 'info');
+        out('This will leave all downloads during installation vulnerable to Man-In-The-Middle (MITM) attacks', 'info');
+    }
+}
+
+/**
+* Outputs an array of issues
+*
+* @param array $issues
+*/
+function outputIssues($issues)
+{
+    foreach ($issues as $issue) {
+        out($issue, 'info');
+    }
+    out('');
+}
+
+/**
+* Checks platform configuration for common incompatibility issues
+*
+* @param array $errors Populated by method
+* @param array $warnings Populated by method
+*
+* @return bool If any errors or warnings have been found
+*/
+function getPlatformIssues(&$errors, &$warnings)
 {
     $errors = array();
     $warnings = array();
 
-    $iniPath = php_ini_loaded_file();
-    $displayIniMessage = false;
-    if ($iniPath) {
-        $iniMessage = PHP_EOL.PHP_EOL.'The php.ini used by your command-line PHP is: ' . $iniPath;
+    if ($iniPath = php_ini_loaded_file()) {
+        $iniMessage = PHP_EOL.'The php.ini used by your command-line PHP is: ' . $iniPath;
     } else {
-        $iniMessage = PHP_EOL.PHP_EOL.'A php.ini file does not exist. You will have to create one.';
+        $iniMessage = PHP_EOL.'A php.ini file does not exist. You will have to create one.';
     }
     $iniMessage .= PHP_EOL.'If you can not modify the ini file, you can also run `php -d option=value` to modify ini values on the fly. You can use -d multiple times.';
 
     if (ini_get('detect_unicode')) {
-        $errors['unicode'] = 'On';
+        $errors['unicode'] = array(
+            'The detect_unicode setting must be disabled.',
+            'Add the following to the end of your `php.ini`:',
+            '    detect_unicode = Off',
+            $iniMessage
+        );
     }
 
     if (extension_loaded('suhosin')) {
         $suhosin = ini_get('suhosin.executor.include.whitelist');
         $suhosinBlacklist = ini_get('suhosin.executor.include.blacklist');
         if (false === stripos($suhosin, 'phar') && (!$suhosinBlacklist || false !== stripos($suhosinBlacklist, 'phar'))) {
-            $errors['suhosin'] = $suhosin;
+            $errors['suhosin'] = array(
+                'The suhosin.executor.include.whitelist setting is incorrect.',
+                'Add the following to the end of your `php.ini` or suhosin.ini (Example path [for Debian]: /etc/php5/cli/conf.d/suhosin.ini):',
+                '    suhosin.executor.include.whitelist = phar '.$suhosin,
+                $iniMessage
+            );
         }
     }
 
     if (!function_exists('json_decode')) {
-        $errors['json'] = true;
+        $errors['json'] = array(
+            'The json extension is missing.',
+            'Install it or recompile php without --disable-json'
+        );
     }
 
     if (!extension_loaded('Phar')) {
-        $errors['phar'] = true;
+        $errors['phar'] = array(
+            'The phar extension is missing.',
+            'Install it or recompile php without --disable-phar'
+        );
     }
 
     if (!extension_loaded('filter')) {
-        $errors['filter'] = true;
+        $errors['filter'] = array(
+            'The filter extension is missing.',
+            'Install it or recompile php without --disable-filter'
+        );
     }
 
     if (!extension_loaded('hash')) {
-        $errors['hash'] = true;
+        $errors['hash'] = array(
+            'The hash extension is missing.',
+            'Install it or recompile php without --disable-hash'
+        );
     }
 
     if (!extension_loaded('iconv') && !extension_loaded('mbstring')) {
-        $errors['iconv_mbstring'] = true;
+        $errors['iconv_mbstring'] = array(
+            'The iconv OR mbstring extension is required and both are missing.',
+            'Install either of them or recompile php without --disable-iconv'
+        );
     }
 
     if (!ini_get('allow_url_fopen')) {
-        $errors['allow_url_fopen'] = true;
+        $errors['allow_url_fopen'] = array(
+            'The allow_url_fopen setting is incorrect.',
+            'Add the following to the end of your `php.ini`:',
+            '    allow_url_fopen = On',
+            $iniMessage
+        );
     }
 
     if (extension_loaded('ionCube Loader') && ioncube_loader_iversion() < 40009) {
-        $errors['ioncube'] = ioncube_loader_version();
+        $ioncube = ioncube_loader_version();
+        $errors['ioncube'] = array(
+            'Your ionCube Loader extension ('.$ioncube.') is incompatible with Phar files.',
+            'Upgrade to ionCube 4.0.9 or higher or remove this line (path may be different) from your `php.ini` to disable it:',
+            '    zend_extension = /usr/lib/php5/20090626+lfs/ioncube_loader_lin_5.3.so',
+            $iniMessage
+        );
     }
 
     if (version_compare(PHP_VERSION, '5.3.2', '<')) {
-        $errors['php'] = PHP_VERSION;
+        $errors['php'] = array(
+            'Your PHP ('.PHP_VERSION.') is too old, you must upgrade to PHP 5.3.2 or higher.'
+        );
     }
 
     if (version_compare(PHP_VERSION, '5.3.4', '<')) {
-        $warnings['php'] = PHP_VERSION;
+        $warnings['php'] = array(
+            'Your PHP ('.PHP_VERSION.') is quite old, upgrading to PHP 5.3.4 or higher is recommended.',
+            'Composer works with 5.3.2+ for most people, but there might be edge case issues.'
+        );
     }
 
-    if (!extension_loaded('openssl') && true === $disableTls) {
-        $warnings['openssl'] = true;
-    } elseif (!extension_loaded('openssl')) {
-        $errors['openssl'] = true;
+    if (!extension_loaded('openssl')) {
+        $warnings['openssl'] = array(
+            'The openssl extension is missing, which means that secure HTTPS transfers are impossible.',
+            'If possible you should enable it or recompile php with --with-openssl'
+        );
     }
 
     if (extension_loaded('openssl') && OPENSSL_VERSION_NUMBER < 0x1000100f) {
-        $warnings['openssl_version'] = true;
+        // Attempt to parse version number out, fallback to whole string value.
+        $opensslVersion = trim(strstr(OPENSSL_VERSION_TEXT, ' '));
+        $opensslVersion = substr($opensslVersion, 0, strpos($opensslVersion, ' '));
+        $opensslVersion = $opensslVersion ? $opensslVersion : OPENSSL_VERSION_TEXT;
+
+        $warnings['openssl_version'] = array(
+            'The OpenSSL library ('.$opensslVersion.') used by PHP does not support TLSv1.2 or TLSv1.1.',
+            'If possible you should upgrade OpenSSL to version 1.0.1 or above.'
+        );
     }
 
     if (!defined('HHVM_VERSION') && !extension_loaded('apcu') && ini_get('apc.enable_cli')) {
-        $warnings['apc_cli'] = true;
+        $warnings['apc_cli'] = array(
+            'The apc.enable_cli setting is incorrect.',
+            'Add the following to the end of your `php.ini`:',
+            '    apc.enable_cli = Off',
+            $iniMessage
+        );
+    }
+
+    if (extension_loaded('xdebug')) {
+        $warnings['xdebug_loaded'] = array(
+            'The xdebug extension is loaded, this can slow down Composer a little.',
+            'Disabling it when using Composer is recommended.'
+        );
+
+        if (ini_get('xdebug.profiler_enabled')) {
+            $warnings['xdebug_profile'] = array(
+                'The xdebug.profiler_enabled setting is enabled, this can slow down Composer a lot.',
+                'Add the following to the end of your `php.ini` to disable it:',
+                '    xdebug.profiler_enabled = 0',
+                $iniMessage
+            );
+        }
     }
 
     ob_start();
@@ -228,339 +406,31 @@ function checkPlatform($quiet, $disableTls)
         $configure = $match[1];
 
         if (false !== strpos($configure, '--enable-sigchild')) {
-            $warnings['sigchild'] = true;
+            $warnings['sigchild'] = array(
+                'PHP was compiled with --enable-sigchild which can cause issues on some platforms.',
+                'Recompile it without this flag if possible, see also:',
+                '    https://bugs.php.net/bug.php?id=22999'
+            );
         }
 
         if (false !== strpos($configure, '--with-curlwrappers')) {
-            $warnings['curlwrappers'] = true;
+            $warnings['curlwrappers'] = array(
+                'PHP was compiled with --with-curlwrappers which will cause issues with HTTP authentication and GitHub.',
+                'Recompile it without this flag if possible'
+            );
         }
     }
 
-    if (!empty($errors)) {
-        out("Some settings on your machine make Composer unable to work properly.", 'error');
-
-        out('Make sure that you fix the issues listed below and run this script again:', 'error');
-        foreach ($errors as $error => $current) {
-            switch ($error) {
-                case 'json':
-                    $text = PHP_EOL."The json extension is missing.".PHP_EOL;
-                    $text .= "Install it or recompile php without --disable-json";
-                    break;
-
-                case 'phar':
-                    $text = PHP_EOL."The phar extension is missing.".PHP_EOL;
-                    $text .= "Install it or recompile php without --disable-phar";
-                    break;
-
-                case 'filter':
-                    $text = PHP_EOL."The filter extension is missing.".PHP_EOL;
-                    $text .= "Install it or recompile php without --disable-filter";
-                    break;
-
-                case 'hash':
-                    $text = PHP_EOL."The hash extension is missing.".PHP_EOL;
-                    $text .= "Install it or recompile php without --disable-hash";
-                    break;
-
-                case 'iconv_mbstring':
-                    $text = PHP_EOL."The iconv OR mbstring extension is required and both are missing.".PHP_EOL;
-                    $text .= "Install either of them or recompile php without --disable-iconv";
-                    break;
-
-                case 'unicode':
-                    $text = PHP_EOL."The detect_unicode setting must be disabled.".PHP_EOL;
-                    $text .= "Add the following to the end of your `php.ini`:".PHP_EOL;
-                    $text .= "    detect_unicode = Off";
-                    $displayIniMessage = true;
-                    break;
-
-                case 'suhosin':
-                    $text = PHP_EOL."The suhosin.executor.include.whitelist setting is incorrect.".PHP_EOL;
-                    $text .= "Add the following to the end of your `php.ini` or suhosin.ini (Example path [for Debian]: /etc/php5/cli/conf.d/suhosin.ini):".PHP_EOL;
-                    $text .= "    suhosin.executor.include.whitelist = phar ".$current;
-                    $displayIniMessage = true;
-                    break;
-
-                case 'php':
-                    $text = PHP_EOL."Your PHP ({$current}) is too old, you must upgrade to PHP 5.3.2 or higher.";
-                    break;
-
-                case 'allow_url_fopen':
-                    $text = PHP_EOL."The allow_url_fopen setting is incorrect.".PHP_EOL;
-                    $text .= "Add the following to the end of your `php.ini`:".PHP_EOL;
-                    $text .= "    allow_url_fopen = On";
-                    $displayIniMessage = true;
-                    break;
-
-                case 'ioncube':
-                    $text = PHP_EOL."Your ionCube Loader extension ($current) is incompatible with Phar files.".PHP_EOL;
-                    $text .= "Upgrade to ionCube 4.0.9 or higher or remove this line (path may be different) from your `php.ini` to disable it:".PHP_EOL;
-                    $text .= "    zend_extension = /usr/lib/php5/20090626+lfs/ioncube_loader_lin_5.3.so";
-                    $displayIniMessage = true;
-                    break;
-
-                case 'openssl':
-                    $text = PHP_EOL."The openssl extension is missing, which means that secure HTTPS transfers are impossible.".PHP_EOL;
-                    $text .= "If possible you should enable it or recompile php with --with-openssl";
-                    break;
-            }
-            if ($displayIniMessage) {
-                $text .= $iniMessage;
-            }
-            out($text, 'info');
-        }
-
-        out('');
-        return false;
+    // Stringify the message arrays
+    foreach ($errors as $key => $value) {
+        $errors[$key] = PHP_EOL.implode(PHP_EOL, $value);
     }
 
-    if (!empty($warnings)) {
-        out("Some settings on your machine may cause stability issues with Composer.", 'error');
-
-        out('If you encounter issues, try to change the following:', 'error');
-        foreach ($warnings as $warning => $current) {
-            switch ($warning) {
-                case 'apc_cli':
-                    $text = PHP_EOL."The apc.enable_cli setting is incorrect.".PHP_EOL;
-                    $text .= "Add the following to the end of your `php.ini`:".PHP_EOL;
-                    $text .= "    apc.enable_cli = Off";
-                    $displayIniMessage = true;
-                    break;
-
-                case 'sigchild':
-                    $text = PHP_EOL."PHP was compiled with --enable-sigchild which can cause issues on some platforms.".PHP_EOL;
-                    $text .= "Recompile it without this flag if possible, see also:".PHP_EOL;
-                    $text .= "    https://bugs.php.net/bug.php?id=22999";
-                    break;
-
-                case 'curlwrappers':
-                    $text = PHP_EOL."PHP was compiled with --with-curlwrappers which will cause issues with HTTP authentication and GitHub.".PHP_EOL;
-                    $text .= "Recompile it without this flag if possible";
-                    break;
-
-                case 'openssl':
-                    $text = PHP_EOL."The openssl extension is missing, which means that secure HTTPS transfers are impossible.".PHP_EOL;
-                    $text .= "If possible you should enable it or recompile php with --with-openssl";
-                    break;
-
-                case 'openssl_version':
-                    // Attempt to parse version number out, fallback to whole string value.
-                    $opensslVersion = trim(strstr(OPENSSL_VERSION_TEXT, ' '));
-                    $opensslVersion = substr($opensslVersion, 0, strpos($opensslVersion, ' '));
-                    $opensslVersion = $opensslVersion ? $opensslVersion : OPENSSL_VERSION_TEXT;
-
-                    $text = PHP_EOL."The OpenSSL library ({$opensslVersion}) used by PHP does not support TLSv1.2 or TLSv1.1.".PHP_EOL;
-                    $text .= "If possible you should upgrade OpenSSL to version 1.0.1 or above.";
-                    break;
-
-                case 'php':
-                    $text = PHP_EOL."Your PHP ({$current}) is quite old, upgrading to PHP 5.3.4 or higher is recommended.".PHP_EOL;
-                    $text .= "Composer works with 5.3.2+ for most people, but there might be edge case issues.";
-                    break;
-            }
-            if ($displayIniMessage) {
-                $text .= $iniMessage;
-            }
-            out($text, 'info');
-        }
-
-        out('');
-        return true;
+    foreach ($warnings as $key => $value) {
+        $warnings[$key] = PHP_EOL.implode(PHP_EOL, $value);
     }
 
-    if (!$quiet) {
-        out("All settings correct for using Composer", 'success');
-    }
-    return true;
-}
-
-/**
- * installs composer to the current working directory
- */
-function installComposer($version, $installDir, $filename, $quiet, $disableTls, $cafile, $channel)
-{
-    $installPath = (is_dir($installDir) ? rtrim($installDir, '/').'/' : '') . $filename;
-    $installDir  = realpath($installDir) ? realpath($installDir) : getcwd();
-    $file        = $installDir.DIRECTORY_SEPARATOR.$filename;
-
-    if (is_readable($file)) {
-        @unlink($file);
-    }
-
-    $home = getHomeDir();
-    file_put_contents($home.'/keys.dev.pub', <<<DEVPUBKEY
------BEGIN PUBLIC KEY-----
-MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAnBDHjZS6e0ZMoK3xTD7f
-FNCzlXjX/Aie2dit8QXA03pSrOTbaMnxON3hUL47Lz3g1SC6YJEMVHr0zYq4elWi
-i3ecFEgzLcj+pZM5X6qWu2Ozz4vWx3JYo1/a/HYdOuW9e3lwS8VtS0AVJA+U8X0A
-hZnBmGpltHhO8hPKHgkJtkTUxCheTcbqn4wGHl8Z2SediDcPTLwqezWKUfrYzu1f
-o/j3WFwFs6GtK4wdYtiXr+yspBZHO3y1udf8eFFGcb2V3EaLOrtfur6XQVizjOuk
-8lw5zzse1Qp/klHqbDRsjSzJ6iL6F4aynBc6Euqt/8ccNAIz0rLjLhOraeyj4eNn
-8iokwMKiXpcrQLTKH+RH1JCuOVxQ436bJwbSsp1VwiqftPQieN+tzqy+EiHJJmGf
-TBAbWcncicCk9q2md+AmhNbvHO4PWbbz9TzC7HJb460jyWeuMEvw3gNIpEo2jYa9
-pMV6cVqnSa+wOc0D7pC9a6bne0bvLcm3S+w6I5iDB3lZsb3A9UtRiSP7aGSo7D72
-8tC8+cIgZcI7k9vjvOqH+d7sdOU2yPCnRY6wFh62/g8bDnUpr56nZN1G89GwM4d4
-r/TU7BQQIzsZgAiqOGXvVklIgAMiV0iucgf3rNBLjjeNEwNSTTG9F0CtQ+7JLwaE
-wSEuAuRm+pRqi8BRnQ/GKUcCAwEAAQ==
------END PUBLIC KEY-----
-DEVPUBKEY
-);
-    file_put_contents($home.'/keys.tags.pub', <<<TAGSPUBKEY
------BEGIN PUBLIC KEY-----
-MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA0Vi/2K6apCVj76nCnCl2
-MQUPdK+A9eqkYBacXo2wQBYmyVlXm2/n/ZsX6pCLYPQTHyr5jXbkQzBw8SKqPdlh
-vA7NpbMeNCz7wP/AobvUXM8xQuXKbMDTY2uZ4O7sM+PfGbptKPBGLe8Z8d2sUnTO
-bXtX6Lrj13wkRto7st/w/Yp33RHe9SlqkiiS4MsH1jBkcIkEHsRaveZzedUaxY0M
-mba0uPhGUInpPzEHwrYqBBEtWvP97t2vtfx8I5qv28kh0Y6t+jnjL1Urid2iuQZf
-noCMFIOu4vksK5HxJxxrN0GOmGmwVQjOOtxkwikNiotZGPR4KsVj8NnBrLX7oGuM
-nQvGciiu+KoC2r3HDBrpDeBVdOWxDzT5R4iI0KoLzFh2pKqwbY+obNPS2bj+2dgJ
-rV3V5Jjry42QOCBN3c88wU1PKftOLj2ECpewY6vnE478IipiEu7EAdK8Zwj2LmTr
-RKQUSa9k7ggBkYZWAeO/2Ag0ey3g2bg7eqk+sHEq5ynIXd5lhv6tC5PBdHlWipDK
-tl2IxiEnejnOmAzGVivE1YGduYBjN+mjxDVy8KGBrjnz1JPgAvgdwJ2dYw4Rsc/e
-TzCFWGk/HM6a4f0IzBWbJ5ot0PIi4amk07IotBXDWwqDiQTwyuGCym5EqWQ2BD95
-RGv89BPD+2DLnJysngsvVaUCAwEAAQ==
------END PUBLIC KEY-----
-TAGSPUBKEY
-);
-
-    if (false === $disableTls && empty($cafile) && !HttpClient::getSystemCaRootBundlePath()) {
-        $errorHandler = new ErrorHandler();
-        set_error_handler(array($errorHandler, 'handleError'));
-
-        $target = $home . '/cacert.pem';
-        $write = file_put_contents($target, HttpClient::getPackagedCaFile(), LOCK_EX);
-        @chmod($target, 0644);
-
-        restore_error_handler();
-
-        if (!$write) {
-            throw new RuntimeException('Unable to write bundled cacert.pem to: '.$target);
-        }
-        $cafile = $target;
-    }
-
-    $httpClient = new HttpClient($disableTls, $cafile);
-    $uriScheme = false === $disableTls ? 'https' : 'http';
-
-    if (!$version) {
-        $versions = json_decode($httpClient->get($uriScheme . '://getcomposer.org/versions'), true);
-        foreach ($versions[$channel] as $candidate) {
-            if ($candidate['min-php'] <= PHP_VERSION_ID) {
-                $version = $candidate['version'];
-                $downloadUrl = $candidate['path'];
-                break;
-            }
-        }
-
-        if (!$version) {
-            throw new RuntimeException('There is no version of Composer available for your PHP version ('.PHP_VERSION.')');
-        }
-    } else {
-        $downloadUrl = "/download/{$version}/composer.phar";
-    }
-
-    $retries = 3;
-    while ($retries--) {
-        if (!$quiet) {
-            out("Downloading $version...", 'info');
-        }
-
-        $url       = "{$uriScheme}://getcomposer.org{$downloadUrl}";
-        $errorHandler = new ErrorHandler();
-        set_error_handler(array($errorHandler, 'handleError'));
-
-        // download signature file
-        if (false === $disableTls) {
-            $signature = $httpClient->get($url.'.sig');
-            if (!$signature) {
-                out('Download failed: '.$errorHandler->message, 'error');
-            } else {
-                $signature = json_decode($signature, true);
-                $signature = base64_decode($signature['sha384']);
-            }
-        }
-
-        $fh = fopen($file, 'w');
-        if (!$fh) {
-            out('Could not create file '.$file.': '.$errorHandler->message, 'error');
-        }
-        if (!fwrite($fh, $httpClient->get($url))) {
-            out('Download failed: '.$errorHandler->message, 'error');
-        }
-        fclose($fh);
-
-        restore_error_handler();
-        if ($errorHandler->message) {
-            continue;
-        }
-
-        try {
-            // create a temp file ending in .phar since the Phar class only accepts that
-            if ('.phar' !== substr($file, -5)) {
-                copy($file, $file.'.tmp.phar');
-                $pharFile = $file.'.tmp.phar';
-            } else {
-                $pharFile = $file;
-            }
-
-            // verify signature
-            if (false === $disableTls) {
-                $pubkeyid = openssl_pkey_get_public('file://'.$home.'/' . (preg_match('{^[0-9a-f]{40}$}', $version) ? 'keys.dev.pub' : 'keys.tags.pub'));
-                $algo = defined('OPENSSL_ALGO_SHA384') ? OPENSSL_ALGO_SHA384 : 'SHA384';
-                if (!in_array('SHA384', openssl_get_md_methods())) {
-                    out('SHA384 is not supported by your openssl extension, could not verify the phar file integrity', 'error');
-                    exit(1);
-                }
-                $verified = 1 === openssl_verify(file_get_contents($file), $signature, $pubkeyid, $algo);
-                openssl_free_key($pubkeyid);
-                if (!$verified) {
-                    out('Signature mismatch, could not verify the phar file integrity', 'error');
-                    exit(1);
-                }
-            }
-
-            // test the phar validity
-            if (!ini_get('phar.readonly')) {
-                $phar = new Phar($pharFile);
-                // free the variable to unlock the file
-                unset($phar);
-            }
-            // clean up temp file if needed
-            if ($file !== $pharFile) {
-                unlink($pharFile);
-            }
-            break;
-        } catch (Exception $e) {
-            if (!$e instanceof UnexpectedValueException && !$e instanceof PharException) {
-                throw $e;
-            }
-            // clean up temp file if needed
-            if ($file !== $pharFile) {
-                unlink($pharFile);
-            }
-            unlink($file);
-            if ($retries) {
-                if (!$quiet) {
-                   out('The download is corrupt, retrying...', 'error');
-                }
-            } else {
-                out('The download is corrupt ('.$e->getMessage().'), aborting.', 'error');
-                exit(1);
-            }
-        }
-    }
-
-    if ($errorHandler->message) {
-        out('The download failed repeatedly, aborting.', 'error');
-        exit(1);
-    }
-
-    chmod($file, 0755);
-
-    if (!$quiet) {
-        out(PHP_EOL."Composer successfully installed to: " . $file, 'success', false);
-        out(PHP_EOL."Use it: php $installPath", 'info');
-    }
+    return !empty($errors) || !empty($warnings);
 }
 
 /**
@@ -589,26 +459,47 @@ function out($text, $color = null, $newLine = true)
 
 function getHomeDir()
 {
-    $home = getenv('COMPOSER_HOME');
-    if (!$home) {
-        if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
-            if (!getenv('APPDATA')) {
-                throw new RuntimeException('The APPDATA or COMPOSER_HOME environment variable must be set for composer to install correctly');
-            }
-            $home = strtr(getenv('APPDATA'), '\\', '/') . '/Composer';
-        } else {
-            if (!getenv('HOME')) {
-                throw new RuntimeException('The HOME or COMPOSER_HOME environment variable must be set for composer to install correctly');
-            }
-            $home = rtrim(getenv('HOME'), '/') . '/.composer';
+    if (($home = getenv('COMPOSER_HOME'))) {
+        return $home;
+    }
+
+    if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
+        if (!($userDir = getenv('APPDATA'))) {
+            throw new RuntimeException('The APPDATA or COMPOSER_HOME environment variable must be set for composer to install correctly');
+        }
+        return rtrim(strtr($userDir, '\\', '/'), '/') . '/Composer';
+    }
+
+    if (!($userDir = getenv('HOME'))) {
+        throw new RuntimeException('The HOME or COMPOSER_HOME environment variable must be set for composer to install correctly');
+    }
+
+    if (is_dir($userDir . '/.composer')) {
+        return $userDir . '/.composer';
+    }
+
+    if (useXdg()) {
+        // XDG Base Directory Specifications
+        if (!($xdgConfig = getenv('XDG_CONFIG_HOME'))) {
+            $xdgConfig = $userDir . '/.config';
+        }
+        return $xdgConfig . '/composer';
+    }
+
+    return $userDir . '/.composer';
+}
+
+/**
+ * @return bool
+ */
+function useXdg()
+{
+    foreach (array_keys($_SERVER) as $key) {
+        if (substr($key, 0, 4) === 'XDG_') {
+            return true;
         }
     }
-
-    if (!is_dir($home)) {
-        @mkdir($home, 0777, true);
-    }
-
-    return $home;
+    return false;
 }
 
 function validateCaFile($contents)
@@ -626,20 +517,596 @@ function validateCaFile($contents)
     return (bool) openssl_x509_parse($contents);
 }
 
-class ErrorHandler
+class Installer
 {
-    public $message = '';
+    protected $quiet;
+    protected $disableTls;
+    protected $cafile;
+    protected $installPath;
+    protected $target;
+    protected $tmpFile;
+    protected $baseUrl;
+    protected $algo;
+    protected $errHandler;
+    protected $httpClient;
+    protected $pubKeys = array();
+    protected $installs = array();
 
-    public function handleError($code, $msg)
+    /**
+    * Constructor - must not do anything that throws an exception
+    *
+    * @param bool $quiet Quiet mode
+    * @param bool $disableTls Bypass tls
+    * @param mixed $cafile Path to CA bundle, or false
+    */
+    public function __construct($quiet, $disableTls, $caFile)
     {
-        if ($this->message) {
-            $this->message .= "\n";
+        if (($this->quiet = $quiet)) {
+            ob_start();
         }
-        $this->message .= preg_replace('{^copy\(.*?\): }', '', $msg);
+        $this->disableTls = $disableTls;
+        $this->cafile = $caFile;
+        $this->errHandler = new ErrorHandler();
+    }
+
+    /**
+    * Runs the installer
+    *
+    * @param mixed $version Specific version to install, or false
+    * @param mixed $installDir Specific installation directory, or false
+    * @param string $filename Specific filename to save to, or composer.phar
+    * @param string $channel Specific version channel to use
+    * @throws Exception If anything other than a RuntimeException is caught
+    *
+    * @return bool If the installation succeeded
+    */
+    public function run($version, $installDir, $filename, $channel)
+    {
+        try {
+            $this->initTargets($installDir, $filename);
+            $this->initTls();
+            $this->httpClient = new HttpClient($this->disableTls, $this->cafile);
+            $result = $this->install($version, $channel);
+        } catch (Exception $e) {
+            $result = false;
+        }
+
+        // Always clean up
+        $this->cleanUp($result);
+
+        if (isset($e)) {
+            // Rethrow anything that is not a RuntimeException
+            if (!$e instanceof RuntimeException) {
+                throw $e;
+            }
+            out($e->getMessage(), 'error');
+        }
+        return $result;
+    }
+
+    /**
+    * Initialization methods to set the required filenames and composer url
+    *
+    * @param mixed $installDir Specific installation directory, or false
+    * @param string $filename Specific filename to save to, or composer.phar
+    * @throws RuntimeException If the installation directory is not writable
+    */
+    protected function initTargets($installDir, $filename)
+    {
+        $this->installPath = (is_dir($installDir) ? rtrim($installDir, '/').'/' : '').$filename;
+        $installDir = realpath($installDir) ? realpath($installDir) : getcwd();
+
+        if (!is_writeable($installDir)) {
+            throw new RuntimeException('The installation directory "'.$installDir.'" is not writable');
+        }
+
+        $this->target = $installDir.DIRECTORY_SEPARATOR.$filename;
+        $this->tmpFile = $installDir.DIRECTORY_SEPARATOR.basename($this->target, '.phar').'-temp.phar';
+
+        $uriScheme = $this->disableTls ? 'http' : 'https';
+        $this->baseUrl = $uriScheme.'://getcomposer.org';
+    }
+
+    /**
+    * A wrapper around methods to check tls and write public keys
+    * @throws RuntimeException If SHA384 is not supported
+    */
+    protected function initTls()
+    {
+        if ($this->disableTls) {
+            return;
+        }
+
+        if (!in_array('SHA384', openssl_get_md_methods())) {
+            throw new RuntimeException('SHA384 is not supported by your openssl extension');
+        }
+
+        $this->algo = defined('OPENSSL_ALGO_SHA384') ? OPENSSL_ALGO_SHA384 : 'SHA384';
+        $home = $this->getComposerHome();
+
+        $this->pubKeys = array(
+            'dev' => $this->installKey(self::getPKDev(), $home, 'keys.dev.pub'),
+            'tags' => $this->installKey(self::getPKTags(), $home, 'keys.tags.pub')
+        );
+
+        if (empty($this->cafile) && !HttpClient::getSystemCaRootBundlePath()) {
+            $this->cafile = $this->installKey(HttpClient::getPackagedCaFile(), $home, 'cacert.pem');
+        }
+    }
+
+    /**
+    * Returns the Composer home directory, creating it if required
+    * @throws Runtime Exception If the directory cannot be created
+    *
+    * @return string
+    */
+    protected function getComposerHome()
+    {
+        $home = getHomeDir();
+
+        if (!is_dir($home)) {
+            $this->errHandler->start();
+
+            if (!mkdir($home, 0777, true)) {
+                throw new RuntimeException(sprintf(
+                    'Unable to create Composer home directory "%s": %s',
+                    $home,
+                    $this->errHandler->message
+                ));
+            }
+            $this->installs[] = $home;
+            $this->errHandler->stop();
+        }
+        return $home;
+    }
+
+    /**
+    * Writes public key data to disc
+    *
+    * @param string $data The public key(s) in pem format
+    * @param string $path The directory to write to
+    * @param string $filename The name of the file
+    * @throws RuntimeException If the file cannot be written
+    *
+    * @return string The path to the saved data
+    */
+    protected function installKey($data, $path, $filename)
+    {
+        $this->errHandler->start();
+
+        $target = $path.DIRECTORY_SEPARATOR.$filename;
+        $installed = file_exists($target);
+        $write = file_put_contents($target, $data, LOCK_EX);
+        @chmod($target, 0644);
+
+        $this->errHandler->stop();
+
+        if (!$write) {
+            throw new RuntimeException(sprintf('Unable to write %s to: %s', $filename, $path));
+        }
+
+        if (!$installed) {
+            $this->installs[] = $target;
+        }
+
+        return $target;
+    }
+
+    /**
+    * The main install function
+    *
+    * @param mixed $version Specific version to install, or false
+    * @param string $channel Version channel to use
+    *
+    * @return bool If the installation succeeded
+    */
+    protected function install($version, $channel)
+    {
+        $retries = 3;
+        $result = false;
+        $infoMsg = 'Downloading...';
+        $infoType = 'info';
+
+        while ($retries--) {
+            if (!$this->quiet) {
+                out($infoMsg, $infoType);
+                $infoMsg = 'Retrying...';
+                $infoType = 'error';
+            }
+
+            if (!$this->getVersion($channel, $version, $url, $error)) {
+                out($error, 'error');
+                continue;
+            }
+
+            if (!$this->downloadToTmp($url, $signature, $error)) {
+                out($error, 'error');
+                continue;
+            }
+
+            if (!$this->verifyAndSave($version, $signature, $error)) {
+                out($error, 'error');
+                continue;
+            }
+
+            $result = true;
+            break;
+        }
+
+        if (!$this->quiet) {
+            if ($result) {
+                out(PHP_EOL."Composer (version {$version}) successfully installed to: {$this->target}", 'success');
+                out("Use it: php {$this->installPath}", 'info');
+                out('');
+            } else {
+                out('The download failed repeatedly, aborting.', 'error');
+            }
+        }
+        return $result;
+    }
+
+    /**
+    * Sets the version url, downloading version data if required
+    *
+    * @param string $channel Version channel to use
+    * @param false|string $version Version to install, or set by method
+    * @param null|string $url The versioned url, set by method
+    * @param null|string $error Set by method on failure
+    *
+    * @return bool If the operation succeeded
+    */
+    protected function getVersion($channel, &$version, &$url, &$error)
+    {
+        $error = '';
+
+        if ($version) {
+            if (empty($url)) {
+                $url = $this->baseUrl."/download/{$version}/composer.phar";
+            }
+            return true;
+        }
+
+        $errFmt = 'The "%s" file could not be %s: %s';
+        $verUrl = $this->baseUrl.'/versions';
+        $this->errHandler->start();
+
+        if (!$json = $this->httpClient->get($verUrl)) {
+            $error = sprintf($errFmt, $verUrl, 'downloaded', $this->errHandler->message);
+
+        } elseif (!$data = json_decode($json, true)) {
+            $error = sprintf($errFmt, $verUrl, 'json-decoded', $this->getJsonError());
+
+        } else {
+            $this->parseVersionData($data, $channel, $version, $url);
+        }
+
+        $this->errHandler->stop();
+        return empty($error);
+    }
+
+    /**
+    * A wrapper around the methods needed to download and save the phar
+    *
+    * @param string $url The versioned download url
+    * @param null|string $signature Set by method on successful download
+    * @param null|string $error Set by method on failure
+    *
+    * @return bool If the operation succeeded
+    */
+    protected function downloadToTmp($url, &$signature, &$error)
+    {
+        $error = '';
+        $errFmt = 'The "%s" file could not be downloaded: %s';
+        $sigUrl = $url.'.sig';
+        $this->errHandler->start();
+
+        if (!$fh = fopen($this->tmpFile, 'w')) {
+            $error = sprintf('Could not create file "%s": %s', $this->tmpFile, $this->errHandler->message);
+
+        } elseif (!$this->getSignature($sigUrl, $signature)) {
+            $error = sprintf($errFmt, $sigUrl, $this->errHandler->message);
+
+        } elseif (!fwrite($fh, $this->httpClient->get($url))) {
+            $error = sprintf($errFmt, $url, $this->errHandler->message);
+        }
+
+        if (is_resource($fh)) {
+            fclose($fh);
+        }
+        $this->errHandler->stop();
+        return empty($error);
+    }
+
+    /**
+    * Verifies the downloaded file and saves it to the target location
+    *
+    * @param string $version The composer version downloaded
+    * @param string $signature The digital signature to check
+    * @param null|string $error Set by method on failure
+    *
+    * @return bool If the operation succeeded
+    */
+    protected function verifyAndSave($version, $signature, &$error)
+    {
+        $error = '';
+
+        if (!$this->validatePhar($this->tmpFile, $pharError)) {
+            $error = 'The download is corrupt: '.$pharError;
+
+        } elseif (!$this->verifySignature($version, $signature, $this->tmpFile)) {
+            $error = 'Signature mismatch, could not verify the phar file integrity';
+
+        } else {
+            $this->errHandler->start();
+
+            if (!rename($this->tmpFile, $this->target)) {
+                $error = sprintf('Could not write to file "%s": %s', $this->target, $this->errHandler->message);
+            }
+            chmod($this->target, 0755);
+            $this->errHandler->stop();
+        }
+
+        return empty($error);
+    }
+
+    /**
+    * Parses an array of version data to match the required channel
+    *
+    * @param array $data Downloaded version data
+    * @param mixed $channel Version channel to use
+    * @param false|string $version Set by method
+    * @param mixed $url The versioned url, set by method
+    */
+    protected function parseVersionData(array $data, $channel, &$version, &$url)
+    {
+        foreach ($data[$channel] as $candidate) {
+            if ($candidate['min-php'] <= PHP_VERSION_ID) {
+                $version = $candidate['version'];
+                $url = $this->baseUrl.$candidate['path'];
+                break;
+            }
+        }
+
+        if (!$version) {
+            throw new RuntimeException('There is no version of Composer available for your PHP version ('.PHP_VERSION.')');
+        }
+    }
+
+    /**
+    * Downloads the digital signature of required phar file
+    *
+    * @param string $url The signature url
+    * @param null|string $signature Set by method on success
+    *
+    * @return bool If the download succeeded
+    */
+    protected function getSignature($url, &$signature)
+    {
+        if (!$result = $this->disableTls) {
+            $signature = $this->httpClient->get($url);
+
+            if ($signature) {
+                $signature = json_decode($signature, true);
+                $signature = base64_decode($signature['sha384']);
+                $result = true;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+    * Verifies the signature of the downloaded phar
+    *
+    * @param string $version The composer versione
+    * @param string $signature The downloaded digital signature
+    * @param string $file The temp phar file
+    *
+    * @return bool If the operation succeeded
+    */
+    protected function verifySignature($version, $signature, $file)
+    {
+        if (!$result = $this->disableTls) {
+            $path = preg_match('{^[0-9a-f]{40}$}', $version) ? $this->pubKeys['dev'] : $this->pubKeys['tags'];
+            $pubkeyid = openssl_pkey_get_public('file://'.$path);
+
+            $result = 1 === openssl_verify(
+                file_get_contents($file),
+                $signature,
+                $pubkeyid,
+                $this->algo
+            );
+
+            openssl_free_key($pubkeyid);
+        }
+
+        return $result;
+    }
+
+    /**
+    * Validates the downloaded phar file
+    *
+    * @param string $pharFile The temp phar file
+    * @param null|string $error Set by method on failure
+    *
+    * @return bool If the operation succeeded
+    */
+    protected function validatePhar($pharFile, &$error)
+    {
+        if (ini_get('phar.readonly')) {
+            return true;
+        }
+
+        try {
+            // Test the phar validity
+            $phar = new Phar($pharFile);
+            // Free the variable to unlock the file
+            unset($phar);
+            $result = true;
+
+        } catch (Exception $e) {
+            if (!$e instanceof UnexpectedValueException && !$e instanceof PharException) {
+                throw $e;
+            }
+            $error = $e->getMessage();
+            $result = false;
+        }
+        return $result;
+    }
+
+    /**
+    * Returns a string representation of the last json error
+    *
+    * @return string The error string or code
+    */
+    protected function getJsonError()
+    {
+        if (function_exists('json_last_error_msg')) {
+            return json_last_error_msg();
+        } else {
+            return 'json_last_error = '.json_last_error();
+        }
+    }
+
+    /**
+    * Cleans up resources at the end of the installation
+    *
+    * @param bool $result If the installation succeeded
+    */
+    protected function cleanUp($result)
+    {
+        if (!$result) {
+            // Output buffered errors
+            if ($this->quiet) {
+                $this->outputErrors();
+            }
+            // Clean up stuff we created
+            $this->uninstall();
+        }
+    }
+
+    /**
+    * Outputs unique errors when in quiet mode
+    *
+    */
+    protected function outputErrors()
+    {
+        $errors = explode(PHP_EOL, ob_get_clean());
+        $shown = array();
+
+        foreach ($errors as $error) {
+            if ($error && !in_array($error, $shown)) {
+                out($error, 'error');
+                $shown[] = $error;
+            }
+        }
+    }
+
+    /**
+    * Uninstalls newly-created files and dirs on failure
+    *
+    */
+    protected function uninstall()
+    {
+        foreach (array_reverse($this->installs) as $target) {
+            if (is_file($target)) {
+                @unlink($target);
+            } elseif (is_dir($target)) {
+                @rmdir($target);
+            }
+        }
+    }
+
+    public static function getPKDev()
+    {
+        return <<<PKDEV
+-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAnBDHjZS6e0ZMoK3xTD7f
+FNCzlXjX/Aie2dit8QXA03pSrOTbaMnxON3hUL47Lz3g1SC6YJEMVHr0zYq4elWi
+i3ecFEgzLcj+pZM5X6qWu2Ozz4vWx3JYo1/a/HYdOuW9e3lwS8VtS0AVJA+U8X0A
+hZnBmGpltHhO8hPKHgkJtkTUxCheTcbqn4wGHl8Z2SediDcPTLwqezWKUfrYzu1f
+o/j3WFwFs6GtK4wdYtiXr+yspBZHO3y1udf8eFFGcb2V3EaLOrtfur6XQVizjOuk
+8lw5zzse1Qp/klHqbDRsjSzJ6iL6F4aynBc6Euqt/8ccNAIz0rLjLhOraeyj4eNn
+8iokwMKiXpcrQLTKH+RH1JCuOVxQ436bJwbSsp1VwiqftPQieN+tzqy+EiHJJmGf
+TBAbWcncicCk9q2md+AmhNbvHO4PWbbz9TzC7HJb460jyWeuMEvw3gNIpEo2jYa9
+pMV6cVqnSa+wOc0D7pC9a6bne0bvLcm3S+w6I5iDB3lZsb3A9UtRiSP7aGSo7D72
+8tC8+cIgZcI7k9vjvOqH+d7sdOU2yPCnRY6wFh62/g8bDnUpr56nZN1G89GwM4d4
+r/TU7BQQIzsZgAiqOGXvVklIgAMiV0iucgf3rNBLjjeNEwNSTTG9F0CtQ+7JLwaE
+wSEuAuRm+pRqi8BRnQ/GKUcCAwEAAQ==
+-----END PUBLIC KEY-----
+PKDEV;
+    }
+
+    public static function getPKTags()
+    {
+        return <<<PKTAGS
+-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA0Vi/2K6apCVj76nCnCl2
+MQUPdK+A9eqkYBacXo2wQBYmyVlXm2/n/ZsX6pCLYPQTHyr5jXbkQzBw8SKqPdlh
+vA7NpbMeNCz7wP/AobvUXM8xQuXKbMDTY2uZ4O7sM+PfGbptKPBGLe8Z8d2sUnTO
+bXtX6Lrj13wkRto7st/w/Yp33RHe9SlqkiiS4MsH1jBkcIkEHsRaveZzedUaxY0M
+mba0uPhGUInpPzEHwrYqBBEtWvP97t2vtfx8I5qv28kh0Y6t+jnjL1Urid2iuQZf
+noCMFIOu4vksK5HxJxxrN0GOmGmwVQjOOtxkwikNiotZGPR4KsVj8NnBrLX7oGuM
+nQvGciiu+KoC2r3HDBrpDeBVdOWxDzT5R4iI0KoLzFh2pKqwbY+obNPS2bj+2dgJ
+rV3V5Jjry42QOCBN3c88wU1PKftOLj2ECpewY6vnE478IipiEu7EAdK8Zwj2LmTr
+RKQUSa9k7ggBkYZWAeO/2Ag0ey3g2bg7eqk+sHEq5ynIXd5lhv6tC5PBdHlWipDK
+tl2IxiEnejnOmAzGVivE1YGduYBjN+mjxDVy8KGBrjnz1JPgAvgdwJ2dYw4Rsc/e
+TzCFWGk/HM6a4f0IzBWbJ5ot0PIi4amk07IotBXDWwqDiQTwyuGCym5EqWQ2BD95
+RGv89BPD+2DLnJysngsvVaUCAwEAAQ==
+-----END PUBLIC KEY-----
+PKTAGS;
     }
 }
 
-class HttpClient {
+class ErrorHandler
+{
+    public $message;
+    protected $active;
+
+    /**
+    * Handle php errors
+    *
+    * @param mixed $code The error code
+    * @param mixed $msg The error message
+    */
+    public function handleError($code, $msg)
+    {
+        if ($this->message) {
+            $this->message .= PHP_EOL;
+        }
+        $this->message .= preg_replace('{^file_get_contents\(.*?\): }', '', $msg);
+    }
+
+    /**
+    * Starts error-handling if not already active
+    *
+    * Any message is cleared
+    */
+    public function start()
+    {
+        if (!$this->active) {
+            set_error_handler(array($this, 'handleError'));
+            $this->active = true;
+        }
+        $this->message = '';
+    }
+
+    /**
+    * Stops error-handling if active
+    *
+    * Any message is preserved until the next call to start()
+    */
+    public function stop()
+    {
+        if ($this->active) {
+            restore_error_handler();
+            $this->active = false;
+        }
+    }
+}
+
+class HttpClient
+{
 
     private $options = array('http' => array());
     private $disableTls = false;
@@ -729,7 +1196,7 @@ class HttpClient {
             'DHE-DSS-AES256-SHA',
             'DHE-RSA-AES256-SHA',
             'AES128-GCM-SHA256',
-             'AES256-GCM-SHA384',
+            'AES256-GCM-SHA384',
             'ECDHE-RSA-RC4-SHA',
             'ECDHE-ECDSA-RC4-SHA',
             'AES128',
@@ -827,7 +1294,7 @@ class HttpClient {
                 'proxy'           => $proxyURL,
             );
 
-            // enabled request_fulluri unless it is explicitly disabled
+            // enable request_fulluri unless it is explicitly disabled
             switch (parse_url($url, PHP_URL_SCHEME)) {
                 case 'http': // default request_fulluri to true
                     $reqFullUriEnv = getenv('HTTP_PROXY_REQUEST_FULLURI');
@@ -4919,5 +5386,4 @@ hkIGuUE=
 -----END CERTIFICATE-----
 CACERT;
     }
-
 }


### PR DESCRIPTION
These changes make it easier for the Composer-Setup installer to parse output and present error/informational messages to the user. The following fixes have been made:

- Catches exceptions *thrown* in installComposer, output e->message and exit 1
- Removes composer home and public keys if created and installation fails
- Continues retry loop on first error
- Reduces retry error messages for quiet mode

Note that some are only fixes in the sense that they don't work very well in a managed installation, rather than a command-line one.

It would be useful if some of the code shared between the installer and composer could be put in its own repo (not necessarily as a package, like the recent ca-bundle) to save having to duplicate changes.