### PR TITLE
Add a recommendation for zlib

### DIFF
--- a/web/installer
+++ b/web/installer
@@ -355,6 +355,15 @@ function getPlatformIssues(&$errors, &$warnings)
         }
     }
 
+    if (!extension_loaded('zlib')) {
+        $warnings['zlib'] = array(
+            'The zlib extension is not loaded, this can slow down Composer a lot.',
+            'If possible, install it or recompile php with `--with-zlib`',
+            $iniMessage
+        );
+        
+    }
+
     ob_start();
     phpinfo(INFO_GENERAL);
     $phpinfo = ob_get_clean();


### PR DESCRIPTION
When zlib is not installed, Composer is really slow as some metadata files from Packagist can be really huge (for instance, the Symfony YAML one is more than 1.3Mb :)). So, I think we need to recommend people to install or enable zlib when possible.
