### PR TITLE
Cant use the installer to get the 1.3.0-RC version

### DIFF
--- a/web/installer
+++ b/web/installer
@@ -158,7 +158,7 @@ function checkParams($installDir, $version, $cafile)
         $result = false;
     }
 
-    if (false !== $version && 1 !== preg_match('/^\d+\.\d+\.\d+(\-(alpha|beta)\d+)*$/', $version)) {
+    if (false !== $version && 1 !== preg_match('/^\d+\.\d+\.\d+(\-(alpha|beta|RC)\d+)*$/', $version)) {
         out("The defined install version ({$version}) does not match release pattern.", 'info');
         $result = false;
     }


### PR DESCRIPTION
Im burning an AMI that I do not want --version to change without explicitly doing so, therefore I'd like to have --version=1.3.0-RC