### PR TITLE
Add search to documentation

### DIFF
--- a/views/doc.list.html.twig
+++ b/views/doc.list.html.twig
@@ -1,6 +1,11 @@
 {% extends "layout.html.twig" %}
 
 {% block content %}
+
+    <div id="search" class="clearfix">
+        <input id="docsearch" type="text" placeholder="Search documentation">
+    </div>
+
     <h1>Book</h1>
     <ul>
     {% for filename, data in book %}

--- a/views/doc.show.html.twig
+++ b/views/doc.show.html.twig
@@ -3,6 +3,11 @@
 {% block title %}{% if title is not empty %}{{ title }} - {% endif %}{{ parent() }}{% endblock %}
 
 {% block content %}
+
+    <div id="search" class="clearfix">
+      <input id="docsearch" type="text" placeholder="Search documentation">
+    </div>
+
     {% if toc|length %}
         <ul class="toc">
             {{ _self.tocTree(toc|length > 3 ? toc : toc.1) }}

--- a/views/layout.html.twig
+++ b/views/layout.html.twig
@@ -12,6 +12,8 @@
         <link rel="stylesheet" href="{{ app.request.basePath }}/css/libs/prism.css?v=6">
 
         <script src="{{ app.request.basePath }}/js/libs/modernizr-2.0.6.min.js"></script>
+
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css">
     </head>
 
     <body>
@@ -45,6 +47,14 @@
             (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];g.async=1;
             g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
             s.parentNode.insertBefore(g,s)}(document,'script'));
+        </script>
+        <script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js"></script>
+        <script type="text/javascript"> docsearch({
+          apiKey: '8f77725b2f2db4166675acc6e8ea3526',
+          indexName: 'getcomposer',
+          inputSelector: '#docsearch',
+          debug: true
+        });
         </script>
     </body>
 </html>

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -229,6 +229,19 @@ th, td {
   padding: 0.5em;
 }
 
+#search {
+  text-align: right;
+}
+
+input#docsearch {
+  width: 260px;
+  padding: 4px 4px 2px 4px;
+}
+
+.ds-dropdown-menu {
+  width: 600px;
+}
+
 /* ==|== non-semantic helper classes ======================================== */
 .ir { display: block; border: 0; text-indent: -999em; overflow: hidden; background-color: transparent; background-repeat: no-repeat; text-align: left; direction: ltr; }
 .ir br { display: none; }


### PR DESCRIPTION
This is my contribution to add search capability to the composer.org website. I believe you have great content but it's not always easy to find what we're looking for.

I used [DocSearch](https://community.algolia.com/docsearch/) from Algolia, it powers the search of a lot of documentation, like Symfony, Laravel, Vue.js, Yarn or React for instance.

This PR aims to open a conversation. I tried to integrate it as well as possible. I'd be happy to edit my contribution according to your needs.

### Demo

![composer-demo-docsearch](https://user-images.githubusercontent.com/1525636/26836432-20607a50-4adb-11e7-808d-654e64c0a5cc.gif)
