### PR TITLE
Fix #search conflict

### DIFF
--- a/views/doc.list.html.twig
+++ b/views/doc.list.html.twig
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-    <div id="search" class="clearfix">
+    <div id="searchbar" class="clearfix">
         <input id="docsearch" type="text" placeholder="Search documentation">
     </div>
 

--- a/views/doc.show.html.twig
+++ b/views/doc.show.html.twig
@@ -4,7 +4,7 @@
 
 {% block content %}
 
-    <div id="search" class="clearfix">
+    <div id="searchbar" class="clearfix">
       <input id="docsearch" type="text" placeholder="Search documentation">
     </div>
 

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -229,7 +229,7 @@ th, td {
   padding: 0.5em;
 }
 
-#search {
+#searchbar {
   text-align: right;
 }
 


### PR DESCRIPTION
I just realized that `#search` is used by one of the heading and by the search input container.
It breaks the link the [search command](https://getcomposer.org/doc/03-cli.md#search).

I renamed the the search input container to use `#searchbar`.