### PR TITLE
Clarified installation documentation

### DIFF
--- a/views/download.html.twig
+++ b/views/download.html.twig
@@ -11,7 +11,7 @@
         <h2>Command-line installation</h2>
     {% endif %}
 
-    <p>Run below script in your terminal to get the latest Composer version. For production, use this guide <a href="/doc/faqs/how-to-install-composer-programmatically.md">how to install Composer programmatically</a>.</p>
+    <p>To quickly install Composer in the current directory, run the following script in your terminal. To automate the installation, use <a href="/doc/faqs/how-to-install-composer-programmatically.md">the guide on installing Composer programmatically</a>.</p>
     <pre class="installer">php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
 php composer-setup.php
@@ -26,6 +26,10 @@ php -r "unlink('composer-setup.php');"</pre>
         <li>Remove the installer</li>
     </ul>
 
+    <p class="installer-warning">
+        <strong>WARNING:</strong> Please do not redistribute the install code. It will change with every version of the installer. Instead, please link to this page or check <a href="/doc/faqs/how-to-install-composer-programmatically.md">how to install Composer programmatically</a>.
+    </p>
+ 
     <h2>Installer Options</h2>
 
     <h3>--install-dir</h3>

--- a/views/download.html.twig
+++ b/views/download.html.twig
@@ -11,7 +11,7 @@
         <h2>Command-line installation</h2>
     {% endif %}
 
-    <p>Run this in your terminal to get the latest Composer version:</p>
+    <p>Run below script in your terminal to get the latest Composer version. For production, use this guide <a href="/doc/faqs/how-to-install-composer-programmatically.md">how to install Composer programmatically</a>.</p>
     <pre class="installer">php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
 php composer-setup.php
@@ -25,10 +25,6 @@ php -r "unlink('composer-setup.php');"</pre>
         <li>Run the installer</li>
         <li>Remove the installer</li>
     </ul>
-
-    <p class="installer-warning">
-        WARNING: Please do not redistribute the install code. It will change with every version of the installer. Instead, please link to this page or check <a href="/doc/faqs/how-to-install-composer-programmatically.md">how to install Composer programmatically</a>.
-    </p>
 
     <h2>Installer Options</h2>
 


### PR DESCRIPTION
Hi,

When I needed to automate Composer installation I just went to download page and read "Run this in your terminal to get the latest Composer version" and I was like "Wow that was quick and easy.".

Now after few months I got first failing installation because hash didn't match and I was "What has broken" and went back to download page and looked some time the page, noticed that hash had changed and finally read the "warning"...

Four days from that my co-worker in another project encountered the same issue and then I was "Hey, you are doing it wrong, I know how you need to do it."

Then my other co-worker told that he was skeptic about has comparison and just skipped the hash verification.

All of us read only the fist line "Run this in your terminal to get the latest Composer version" and this commit is my attempt to make this documentation better.

Br,
Markku Roponen