### PR TITLE
Don't use 'just' in documentation footer

### DIFF
--- a/views/doc.show.html.twig
+++ b/views/doc.show.html.twig
@@ -18,7 +18,7 @@
     {{ doc|raw }}
 
     <p class="fork-and-edit">
-        Found a typo? Something is wrong in this documentation? Just <a href="https://github.com/composer/composer/edit/master/doc/{{ file }}">fork and edit</a> it!
+        Found a typo? Something is wrong in this documentation? <a href="https://github.com/composer/composer/edit/master/doc/{{ file }}">Fork and edit</a> it!
     </p>
 {% endblock %}
 


### PR DESCRIPTION
In addition to https://github.com/composer/composer/pull/7206.