### PR TITLE
Use a case insenstive method to check that SHA384 is a supported openssl algorithm

### DIFF
--- a/web/installer
+++ b/web/installer
@@ -646,7 +646,7 @@ class Installer
             return;
         }
 
-        if (!in_array('SHA384', openssl_get_md_methods())) {
+        if (!in_array('sha384', array_map('strtolower', openssl_get_md_methods()))) {
             throw new RuntimeException('SHA384 is not supported by your openssl extension');
         }
 


### PR DESCRIPTION
Currently downloading the installer from https://getcomposer.org/installer and executing it, fails for my system (Arch Linux):
`php 7.2.10`
`openssl 1.1.1`

The problem is, that `openssl_get_md_methods()` only returns the supported algorithms in lowercase, at least in my setup. In earlier versions they seem to return both, i.e. `SHA384` and `sha384`.
To fix this issue I implemented a case insensitive method to detect the algorithm. 

`openssl_verify()` currently does not seem to care about the case at the moment, so I left that part unchanged. 

If this fix is accepted, I will also be happy to create a pull request for the self updater, where the same issue can be found: https://github.com/composer/composer/blob/158e1c95da02cc0b932de74f9a09a1c7b6cf654f/src/Composer/Command/SelfUpdateCommand.php#L223 