### PR TITLE
Composer installer not working on restricted proxy environment.

### DIFF
--- a/web/installer
+++ b/web/installer
@@ -1186,7 +1186,7 @@ class NoProxyPattern
     /**
      * @var string[][]
      */
-    private $proxyMap = [];
+    private $proxyMap = array();
 
     /**
      * Constructor
@@ -1207,7 +1207,7 @@ class NoProxyPattern
             }
 
             if(! isset($this->proxyMap[$address])) {
-                $this->proxyMap[$address] = [$port];
+                $this->proxyMap[$address] = array($port);
             }  else {
                 $this->proxyMap[$address][] = $port;
             }
@@ -1229,7 +1229,9 @@ class NoProxyPattern
             $port = 443;
         }
 
-        preg_match('/^https?\:\/\/(.*?)(\/|$)/', $url, $matches);
+        if (preg_match('/^https?\:\/\/(.*?)(\/|$)/', $url, $matches) === 0) {
+            throw new RuntimeException('Invalid URL scheme');
+        }
         $domain = $matches[1];
 
         if (! isset($this->proxyMap[$domain])) {

--- a/web/installer
+++ b/web/installer
@@ -1183,40 +1183,60 @@ class ErrorHandler
 
 class NoProxyPattern
 {
-    private $rulePort;
+    /**
+     * @var string[][]
+     */
+    private $proxyMap = [];
 
+    /**
+     * Constructor
+     *
+     * @param string $pattern
+     */
     public function __construct($pattern)
     {
         $rules = preg_split('{[\s,]+}', $pattern, null, PREG_SPLIT_NO_EMPTY);
 
-        if ($matches = preg_grep('{getcomposer\.org(?::\d+)?}i', $rules)) {
-            if (strpos($matches[0], ':') !== false) {
-                list(, $port) = explode(':', $matches[0]);
-                $this->rulePort = (int) $port;
+        foreach ($rules as $rule) {
+            $port = '*';
+
+            if (strpos($rule, ':') !== false) {
+                list($address, $port) = explode(':', $rule);
+            } else {
+                $address = $rule;
+            }
+
+            if(! isset($this->proxyMap[$address])) {
+                $this->proxyMap[$address] = [$port];
+            }  else {
+                $this->proxyMap[$address][] = $port;
             }
         }
     }
 
     /**
-     * Returns true if NO_PROXY contains getcomposer.org
+     * Returns true if NO_PROXY contains url specified domain.
      *
-     * @param string $url http(s)://getcomposer.org
+     * @param string $url
      *
      * @return bool
      */
     public function test($url)
     {
-        if (empty($this->rulePort)) {
-            return true;
-        }
-
         if (strpos($url, 'http://') === 0) {
             $port = 80;
         } else {
             $port = 443;
         }
 
-        return $this->rulePort === $port;
+        preg_match('/^https?\:\/\/(.*?)(\/|$)/', $url, $matches);
+        $domain = $matches[1];
+
+        if (! isset($this->proxyMap[$domain])) {
+            return false;
+        } else {
+            return in_array($port, $this->proxyMap[$domain]);
+        }
     }
 }
 


### PR DESCRIPTION
Currently composer installer not working restricted proxy environment.

```
$ export http_proxy=http://127.0.0.1:8080/
$ export https_proxy=http://127.0.0.1:8080/
$ export no_proxy=foo.org,bar.org:80,baz.org:443
$ curl -sS https://getcomposer.org/installer | php # Installer will not use https_proxy.
```

Fixes #144