### PR TITLE
Report Composer-Setup.exe in user-agent header

### DIFF
--- a/web/installer
+++ b/web/installer
@@ -14,15 +14,25 @@ setupEnvironment();
 process(is_array($argv) ? $argv : array());
 
 /**
- * Ensures the environment is sane
+ * Initializes various values
  */
 function setupEnvironment()
 {
     ini_set('display_errors', 1);
+
+    $installer = 'Composer Installer';
+
+    if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
+        if ($version = getenv('COMPOSERSETUP')) {
+            $installer = sprintf('Composer-Setup.exe %s', $version);
+        }
+    }
+
+    define('COMPOSER_INSTALLER', $installer);
 }
 
 /**
- * processes the installer
+ * Processes the installer
  */
 function process($argv)
 {
@@ -73,7 +83,7 @@ function process($argv)
 }
 
 /**
- * displays the help
+ * Displays the help
  */
 function displayHelp()
 {
@@ -1473,7 +1483,7 @@ class HttpClient {
         if (extension_loaded('zlib')) {
             $options['http']['header'] .= "Accept-Encoding: gzip\r\n";
         }
-        $options['http']['header'] .= "User-Agent: Composer Installer\r\n";
+        $options['http']['header'] .= "User-Agent: ".COMPOSER_INSTALLER."\r\n";
         $options['http']['protocol_version'] = 1.1;
         $options['http']['timeout'] = 600;
 


### PR DESCRIPTION
@Seldaek This is something you mentioned might be worth doing yonks ago, so I've incorporated it into the lastest [Composer-Setup.exe](https://github.com/composer/windows-setup/releases/tag/v5.1.0),   which results in the following header:

```
User-Agent: Composer-Setup.exe 5.1.0
```

If you don't want it, I can remove it in the next release.

And happy new year to you and your family.