### PR TITLE
Allow to programmatically install specific major version

### DIFF
--- a/web/installer
+++ b/web/installer
@@ -59,7 +59,16 @@ function process($argv)
     $help       = in_array('--help', $argv);
     $force      = in_array('--force', $argv);
     $quiet      = in_array('--quiet', $argv);
-    $channel    = in_array('--snapshot', $argv) ? 'snapshot' : (in_array('--preview', $argv) ? 'preview' : 'stable');
+    $channel    = 'stable';
+    if (in_array('--snapshot', $argv)) {
+        $channel = 'snapshot';
+    } elseif (in_array('--preview', $argv)) {
+        $channel = 'preview';
+    } elseif (in_array('--1', $argv)) {
+        $channel = '1';
+    } elseif (in_array('--2', $argv)) {
+        $channel = '2';
+    }
     $disableTls = in_array('--disable-tls', $argv);
     $installDir = getOptValue('--install-dir', $argv, false);
     $version    = getOptValue('--version', $argv, false);


### PR DESCRIPTION
Add options to select a 'channel' to install a specific major version.
Closes https://github.com/composer/getcomposer.org/issues/155.

To programmatically install 1.* by default, allowing to set COMPOSER_MAJOR_VERSION=2:
```bash

EXPECTED_CHECKSUM="$(wget -q -O - https://composer.github.io/installer.sig)"
php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"

if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]
then
    >&2 echo 'ERROR: Invalid installer checksum'
    rm composer-setup.php
    exit 1
fi

php composer-setup.php --quiet --${COMPOSER_MAJOR_VERSION:-1}
RESULT=$?
rm composer-setup.php
exit $RESULT
```

Calling `php composer-setup.php --2` and then calling `./composer.phar self-update` results in the stable version being installed.

A PR for the docs to show the usage in 'How do I install Composer programmatically?' will be created in [the composer documentation](https://github.com/composer/composer/tree/83c64a9d191b64689b408906d40943958a6a8eb0/doc).