### PR TITLE
Updates

### DIFF
--- a/web/installer
+++ b/web/installer
@@ -1031,7 +1031,10 @@ class Installer
                 $this->algo
             );
 
-            openssl_free_key($pubkeyid);
+            // PHP 8 automatically frees the key instance and deprecates the function
+            if (PHP_VERSION_ID < 80000) {
+                openssl_free_key($pubkeyid);
+            }
         }
 
         return $result;

--- a/web/installer
+++ b/web/installer
@@ -232,6 +232,7 @@ function checkPlatform(&$warnings, $quiet, $disableTls, $install)
     }
 
     if (!empty($errors)) {
+        // Composer-Setup.exe uses "Some settings" to flag platform errors
         out('Some settings on your machine make Composer unable to work properly.', 'error');
         out('Make sure that you fix the issues listed below and run this script again:', 'error');
         outputIssues($errors);


### PR DESCRIPTION
Fixes `openssl_free_key` deprecation notice in PHP 8 (https://github.com/composer/windows-setup/issues/122) and adds a note about Composer-Setup.exe looking for "Some settings" in the installer output to flag platform errors. 