### PR TITLE
Add note to the download page indicating that the composer installer requires php

### DIFF
--- a/views/download.html.twig
+++ b/views/download.html.twig
@@ -10,6 +10,9 @@
             so you can simply call <code>composer</code> from any directory.
         </p>
         <p>
+            (Requires php is already installed)
+        </p>
+        <p>
             Download and run
             <a href="/Composer-Setup.exe"
                title="Click here to download Composer-Setup installer for Windows"


### PR DESCRIPTION
This page is first on google for `php composer on windows`, so users (like me!) may not see the getting started guide that explains this. (I thought it handled downloading and installing php)