### PR TITLE
Installer updates

### DIFF
--- a/web/installer
+++ b/web/installer
@@ -603,7 +603,7 @@ class Installer
     private $quiet;
     private $disableTls;
     private $cafile;
-    private $installPath;
+    private $displayPath;
     private $target;
     private $tmpFile;
     private $baseUrl;
@@ -684,8 +684,8 @@ class Installer
      */
     protected function initTargets($installDir, $filename)
     {
-        $this->installPath = (is_dir($installDir) ? rtrim($installDir, '/').'/' : '').$filename;
-        $installDir = realpath($installDir) ? realpath($installDir) : getcwd();
+        $this->displayPath = ($installDir ? rtrim($installDir, '/').'/' : '').$filename;
+        $installDir = $installDir ? realpath($installDir) : getcwd();
 
         if (!is_writeable($installDir)) {
             throw new RuntimeException('The installation directory "'.$installDir.'" is not writable');
@@ -827,7 +827,7 @@ class Installer
         if (!$this->quiet) {
             if ($result) {
                 out(PHP_EOL."Composer (version {$version}) successfully installed to: {$this->target}", 'success');
-                out("Use it: php {$this->installPath}", 'info');
+                out("Use it: php {$this->displayPath}", 'info');
                 out('');
             } else {
                 out('The download failed repeatedly, aborting.', 'error');

--- a/web/installer
+++ b/web/installer
@@ -576,7 +576,7 @@ function getUserDir()
 function useXdg()
 {
     foreach (array_keys($_SERVER) as $key) {
-        if (substr($key, 0, 4) === 'XDG_') {
+        if (strpos($key, 'XDG_') === 0) {
             return true;
         }
     }
@@ -1425,7 +1425,7 @@ class HttpClient {
     }
 
     /**
-     * function copied from Composer\Util\StreamContextFactory::getContext
+     * function copied from Composer\Util\StreamContextFactory::initOptions
      *
      * Any changes should be applied there as well, or backported here.
      *
@@ -1466,9 +1466,9 @@ class HttpClient {
 
             if (isset($proxy['port'])) {
                 $proxyURL .= ":" . $proxy['port'];
-            } elseif ('http://' == substr($proxyURL, 0, 7)) {
+            } elseif (strpos($proxyURL, 'http://') === 0) {
                 $proxyURL .= ":80";
-            } elseif ('https://' == substr($proxyURL, 0, 8)) {
+            } elseif (strpos($proxyURL, 'https://') === 0) {
                 $proxyURL .= ":443";
             }
 


### PR DESCRIPTION
A couple of minor tweaks.

The first fixes an edge-case bug when the `--install-dir` option is used and `is_dir` returns true but `realpath` subsequently fails (on Cygwin, passing a Windows formatted path), resulting in the current directory being used.

The second syncs `getMergedStreamContext` with recent updates to `Composer\Util\StreamContextFactory::initOptions`

One thing that might need resolving is the XDG handling (see https://github.com/composer/composer/issues/9096). The installer currently behaves as Composer 1.x, even though it could be downloading a Composer 2 version via --preview, --snapshot or --2 options. How do you think this should be handled?