### PR TITLE
Fix HTTP User-Agent sent by installer

### DIFF
--- a/web/installer
+++ b/web/installer
@@ -31,11 +31,11 @@ function setupEnvironment()
         }
     }
 
-    $installer = 'Composer Installer';
+    $installer = 'ComposerInstaller';
 
     if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
         if ($version = getenv('COMPOSERSETUP')) {
-            $installer = sprintf('Composer-Setup.exe %s', $version);
+            $installer = sprintf('Composer-Setup.exe/%s', $version);
         }
     }
 


### PR DESCRIPTION
The HTTP/1.1 spec mandates that the product identifier does not include
spaces, and that the version is separated from the product identifier by
a slash. See <https://tools.ietf.org/html/rfc7230#section-3.2.6>.

Fixes #166.