### PR TITLE
Add major version selection to installer help and download page

### DIFF
--- a/templates/download.html.twig
+++ b/templates/download.html.twig
@@ -68,13 +68,17 @@ php -r "unlink('composer-setup.php');"</pre>
     <p>The installer provides more options for specific environments, use the
         <code>--help</code> option to see all of them.</p>
 
-    <h2>Preview / Snapshot Releases</h2>
-    <p>By default the installer and <code>composer self-update</code> will download stable versions only. If you
-        would like to help test pre-release versions you can use the <code>--preview</code> flag on either installer
-        or self-update.
-        For snapshot builds which are done from the latest Composer commit, you can use the <code>--snapshot</code>
-        flag.
-    </p>
+    <h2>Download channels</h2>
+    <p>By default the installer and <code>composer self-update</code> will
+        download the latest stable version only. You may select a different
+        download channel though.<br>
+        If you would like to help test pre-release versions you can use the
+        <code>--preview</code> flag on either the installer or self-update.<br>
+        For snapshot builds, which are done from the latest Composer commit,
+        you can use the <code>--snapshot</code> flag.<br>
+        To programmatically install specific major versions you can use the
+        <code>--1</code> or <code>--2</code> flag. Example:</p>
+    <code>php composer-setup.php --preview</code>
 
     <h2>Manual Download</h2>
     <p>If you prefer to download the phar manually, here are the available versions:</p>

--- a/templates/download.html.twig
+++ b/templates/download.html.twig
@@ -47,7 +47,7 @@ php -r "unlink('composer-setup.php');"</pre>
         Instead, please link to this page or check <a href="/doc/faqs/how-to-install-composer-programmatically.md" title="See the instructions on how to install Composer programmatically" aria-label="See the instructions on how to install Composer programmatically">how to install Composer programmatically</a>.
     </p>
 
-    <h2>Installer Options</h2>
+    <h2>Notable Installer Options</h2>
 
     <h3>--install-dir</h3>
     <p>You can install composer to a specific directory by using the <code>--install-dir</code> option and providing
@@ -63,6 +63,10 @@ php -r "unlink('composer-setup.php');"</pre>
     <p>You can install composer to a specific release by using the <code>--version</code> option and providing a
         target release. Example:</p>
     <code>php composer-setup.php --version=1.0.0-alpha8</code>
+
+    <h3>--help</h3>
+    <p>The installer provides more options for specific environments, use the
+        <code>--help</code> option to see all of them.</p>
 
     <h2>Preview / Snapshot Releases</h2>
     <p>By default the installer and <code>composer self-update</code> will download stable versions only. If you

--- a/web/installer
+++ b/web/installer
@@ -120,6 +120,8 @@ Options
 --install-dir="..."  accepts a target installation directory
 --preview            install the latest version from the preview (alpha/beta/rc) channel instead of stable
 --snapshot           install the latest version from the snapshot (dev builds) channel instead of stable
+--1                  install the latest stable version from the major version 1.x channel
+--2                  install the latest stable version from the major version 2.x channel
 --version="..."      accepts a specific version to install instead of the latest
 --filename="..."     accepts a target filename (default: composer.phar)
 --disable-tls        disable SSL/TLS security for file downloads


### PR DESCRIPTION
See #174 

The installer, just like composer self-update, allows to programmatically install specific major versions.

This was documented in the Composer command docs only.

Add the option docs to the installer and download page as well.