### PR TITLE
Mention global install & getting started page on 'Download' page (#172)

### DIFF
--- a/templates/download.html.twig
+++ b/templates/download.html.twig
@@ -41,12 +41,11 @@ php -r "unlink('composer-setup.php');"</pre>
         <li>Remove the installer</li>
     </ul>
 
-    <p>Most likely, you want to put the <code>composer.phar</code> into a directory on your PATH, so you can simply call <code>composer</code> from any directory (<em>Global install</em>):
+    <p>Most likely, you want to put the <code>composer.phar</code> into a directory on your PATH, so you can simply call <code>composer</code> from any directory (<em>Global install</em>), using for example:
     </p>
     <pre class="language-bash">sudo mv composer.phar /usr/local/bin/composer</pre>
     <p>
-        For details,
-        <a href="/doc/00-intro.md#globally">see the instructions on how to install Composer globally</a>.
+        For details, <a href="/doc/00-intro.md#globally">see the instructions on how to install Composer globally</a>.
     </p>
 
     <p class="installer-warning">

--- a/templates/download.html.twig
+++ b/templates/download.html.twig
@@ -41,6 +41,14 @@ php -r "unlink('composer-setup.php');"</pre>
         <li>Remove the installer</li>
     </ul>
 
+    <p>Most likely, you want to put the <code>composer.phar</code> into a directory on your PATH, so you can simply call <code>composer</code> from any directory (<em>Global install</em>):
+    </p>
+    <pre class="language-bash">sudo mv composer.phar /usr/local/bin/composer</pre>
+    <p>
+        For details,
+        <a href="/doc/00-intro.md#globally">see the instructions on how to install Composer globally</a>.
+    </p>
+
     <p class="installer-warning">
         <strong>WARNING:</strong> Please do not redistribute the install code.
         It will change with every version of the installer.


### PR DESCRIPTION
When showing Composer to others, it already happened a couple of times that they ended up on the "Download" page, without knowing how to get the `composer` command into their PATH. I noticed the related issue #172 and decided to add documentation on that 😊 