### PR TITLE
wizardcat.com: Replace dead link with link to Twitter

### DIFF
--- a/templates/index.html.twig
+++ b/templates/index.html.twig
@@ -74,7 +74,7 @@
         </a>
     </p>
     <p>
-        Logo by: <a href="http://wizardcat.com/"
+        Logo by: <a href="https://twitter.com/MAXakaWIZARD"
                     title="Go to WizardCat's website (external link)"
                     aria-label="Go to WizardCat's website (external link)">WizardCat</a>
     </p>


### PR DESCRIPTION
The domain `wizardcat.com` ([Snapshot](https://archive.ph/GB5ws)) has expired and only shows a domain parking page with ads. The same person has a Twitter profile. Maybe it makes sense to just link there?

![Screenshot 2021-08-09 at 11 15 14](https://user-images.githubusercontent.com/4533780/128684262-90b32be9-36fd-41b5-b329-668999ebe6bf.png)
