### PR TITLE
add missing openssl-certificate paths to installer for homebrew on apple silicon

### DIFF
--- a/web/installer
+++ b/web/installer
@@ -1659,6 +1659,8 @@ class HttpClient {
             '/usr/local/etc/ssl/cert.pem', // FreeBSD 10.x
             '/usr/local/etc/openssl/cert.pem', // OS X homebrew, openssl package
             '/usr/local/etc/openssl@1.1/cert.pem', // OS X homebrew, openssl@1.1 package
+            '/opt/homebrew/etc/openssl@3/cert.pem', // macOS silicon homebrew, openssl@3 package
+            '/opt/homebrew/etc/openssl@1.1/cert.pem', // macOS silicon homebrew, openssl@1.1 package
         );
 
         foreach ($caBundlePaths as $caBundle) {


### PR DESCRIPTION
As documented in https://docs.brew.sh/Installation the homebrew install-location has changed on apple silicon. 

> The script installs Homebrew to its default, supported, best prefix (/opt/homebrew for Apple Silicon, /usr/local for macOS Intel and /home/linuxbrew/.linuxbrew for Linux)

Therefore it seems to me advisable to add the new paths for apple silicon installation to the list of openssl ca-bundle-paths in the installer-script. This PR does it.

Cheers 🍻 