### PR TITLE
exit with non-zero status code when hash mismatch

### DIFF
--- a/templates/download.html.twig
+++ b/templates/download.html.twig
@@ -25,7 +25,7 @@
         To automate the installation, use <a href="/doc/faqs/how-to-install-composer-programmatically.md" title="See the instructions on how to install Composer programmatically" aria-label="See the instructions on how to install Composer programmatically">the guide on installing Composer programmatically</a>.
     </p>
     <pre class="installer">php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-php -r "if (hash_file('sha384', 'composer-setup.php') === 'dac665fdc30fdd8ec78b38b9800061b4150413ff2e3b6f88543c636f7cd84f6db9189d43a81e5503cda447da73c7e5b6') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+php -r "if (hash_file('sha384', 'composer-setup.php') === 'dac665fdc30fdd8ec78b38b9800061b4150413ff2e3b6f88543c636f7cd84f6db9189d43a81e5503cda447da73c7e5b6') { echo 'Installer verified'.PHP_EOL; } else { echo 'Installer corrupt'.PHP_EOL; unlink('composer-setup.php'); exit(1); }"
 php composer-setup.php
 php -r "unlink('composer-setup.php');"</pre>
 


### PR DESCRIPTION
In case the hash does not match, exiting with non-zero value is useful during docker build.

For the following Dockerfile, the error during docker build occurs at the line `RUN php composer-setup.php`

```Dockerfile
# ...
RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
RUN php -r "if (hash_file('sha384', 'composer-setup.php') === 'dac665fdc30fdd8ec78b38b9800061b4150413ff2e3b6f88543c636f7cd84f6db9189d43a81e5503cda447da73c7e5b6') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
RUN php composer-setup.php
RUN php -r "unlink('composer-setup.php');"
# ...
```

After this update, docker build fails at the previous line: `RUN php -r "if (hash_file('sha384', 'composer-setup.php') === 'dac665...`.