### PR TITLE
Update stale LTS version support info

### DIFF
--- a/templates/download.html.twig
+++ b/templates/download.html.twig
@@ -169,7 +169,7 @@ php -r "unlink('composer-setup.php');"</pre>
             aria-label="Get the latest composer 2.2.x stable release's SHA256 sum in sha256sum format">sha256sum</a> /
         <a href="{{ path('download_asc_2.2_lts') }}"
             title="Get the latest composer 2.2.x release's PGP signature"
-            aria-label="Get the latest composer 2.2.x release's PGP signature">asc</a>) for PHP 5.3 to 7.1 users
+            aria-label="Get the latest composer 2.2.x release's PGP signature">asc</a>) for <a href="https://github.com/composer/composer?tab=readme-ov-file#requirements">PHP 5.3.2 to 8.1 users</a>
         <br/>
     </p>
     <table aria-label="Composer versions history" role="table" aria-describedby="composer-history-caption">


### PR DESCRIPTION
The version support here is out of sync with the main project. The LTS release supports `8.1`. This commit updates the version range and adds a link to the canonical source of information so that developers can validate and update it easier in the future.