### PR TITLE
Add Japanese translation link in document page

### DIFF
--- a/templates/doc.list.html.twig
+++ b/templates/doc.list.html.twig
@@ -34,6 +34,14 @@
             source
         </a>
     </p>
+
+    <h1>Translations</h1>
+    <p>The Composer documentation is also available in other languages:</p>
+    <ul>
+      <li>
+        <a href="https://phpusers-ja.github.io/composer/">Japanese</a>: Getting Started guide (Book) is fully translated. Selected Articles and FAQs are also available.
+      </li>
+    </ul>
 {% endblock %}
 
 {% macro renderFile(filename, data) %}


### PR DESCRIPTION
Hello,

This merge request adds a link to the Japanese translation of the Composer documentation in the new **Translations** section.

Related issues/merge requests:

- https://github.com/composer/composer/pull/1184
- https://github.com/composer/composer/issues/1983

Thank you!