### PR TITLE
Use COMPOSER_MIRROR for base URL if set

### DIFF
--- a/web/installer
+++ b/web/installer
@@ -781,7 +781,7 @@ class Installer
         $this->tmpFile = $installDir.DIRECTORY_SEPARATOR.basename($this->target, '.phar').'-temp.phar';
 
         $uriScheme = $this->disableTls ? 'http' : 'https';
-        $this->baseUrl = $uriScheme.'://getcomposer.org';
+        $this->baseUrl = getenv('COMPOSER_MIRROR') ?: $uriScheme.'://getcomposer.org';
     }
 
     /**


### PR DESCRIPTION
# Route installer traffic through a corporate mirror

export COMPOSER_MIRROR="https://mirror.internal.example.com/composer"
php composer-setup.php --install-dir=/usr/local/bin --filename=composer
The mirror is expected to serve the same paths as getcomposer.org:
- /versions (version index JSON)
- /download/{version}/composer.phar (binary)