### PR TITLE
Adjust automatic anchor link creation to match Github logic

### DIFF
--- a/src/Controller/DocsController.php
+++ b/src/Controller/DocsController.php
@@ -115,7 +115,7 @@ class DocsController extends AbstractController
                 $id = Preg::replace('{[^a-z0-9]}i', '-', strtolower(trim($node->nodeValue)));
                 $id = Preg::replace('{-+}', '-', $id);
                 if ($count) {
-                    $id .= '-'.($count+1);
+                    $id .= '-'.$count;
                 }
                 $count++;
             } while (isset($ids[$id]));


### PR DESCRIPTION
On GitHub when there are multiple headlines with the same text then the first one will be without any addition and then the count start with 1 (e.g. -1) see https://github.com/composer/composer/blob/main/doc/06-config.md#ignore-unreachable-1

On the docs page this is currently: https://getcomposer.org/doc/06-config.md#ignore-unreachable-2