### PR TITLE
Add eol/maintenance status to versions file and the downloads page

### DIFF
--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\Version\Versions;
 use Composer\Pcre\Preg;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
@@ -80,6 +81,7 @@ class HomeController extends AbstractController
             'page' => 'download',
             'versions' => $versions,
             'latestStable' => $latestStable,
+            'maintenancePolicy' => Versions::policyRows($this->getVersionData($projectDir)),
             'windows' => str_contains($req->headers->get('User-Agent', ''), 'Windows'),
         );
 
@@ -189,7 +191,7 @@ class HomeController extends AbstractController
     }
 
     /**
-     * @return array{path: string, version: string, min-php: int}
+     * @return array{path: string, version: string, min-php: int, lts: bool, maintenance: string, maintenance-until: string|null}
      */
     private function getVersionInfo(string $projectDir, string $channel): array
     {
@@ -217,13 +219,13 @@ class HomeController extends AbstractController
     }
 
     /**
-     * @return array<string, array<int, array{path: string, version: string, min-php: int}>>
+     * @return array<string, array<int, array{path: string, version: string, min-php: int, lts: bool, maintenance: string, maintenance-until: string|null}>>
      */
     private function getVersionData(string $projectDir): array
     {
         $versionData = file_get_contents($projectDir.'/web/versions');
         assert(is_string($versionData), new \RuntimeException("Version file not found in $projectDir/web"));
-        /** @var array<string, array<int, array{path: string, version: string, min-php: int}>> */
+        /** @var array<string, array<int, array{path: string, version: string, min-php: int, lts: bool, maintenance: string, maintenance-until: string|null}>> */
         return json_decode($versionData, true);
     }
 }

--- a/src/Version/MaintenanceStatus.php
+++ b/src/Version/MaintenanceStatus.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Version;
+
+/**
+ * Maintenance tier for a Composer release line.
+ *
+ * The cases form a degrading ladder: a release line starts at Bugfix while it
+ * is the active latest release, then drops to Security, then CriticalSecurity
+ * as it nears end of life, and finally Eol once it is no longer maintained.
+ *
+ * The string values are a public contract exposed in web/versions and consumed
+ * by Composer's self-update/installer.
+ */
+enum MaintenanceStatus: string
+{
+    case Bugfix = 'bugfix';
+    case Security = 'security';
+    case CriticalSecurity = 'critical-security';
+    case Eol = 'eol';
+
+    /**
+     * Short human-readable label for the download page.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::Bugfix => 'Bug & security fixes',
+            self::Security => 'Security fixes only',
+            self::CriticalSecurity => 'Critical security fixes only',
+            self::Eol => 'End of life',
+        };
+    }
+
+    /**
+     * Longer description explaining what users can expect from this tier.
+     */
+    public function description(): string
+    {
+        return match ($this) {
+            self::Bugfix => 'Active release. Receives all bug fixes and security fixes.',
+            self::Security => 'Receives security fixes only, no general bug fixes.',
+            self::CriticalSecurity => 'Receives only critical security fixes, nearing end of life.',
+            self::Eol => 'No longer maintained, no fixes of any kind are provided.',
+        };
+    }
+}

--- a/src/Version/Versions.php
+++ b/src/Version/Versions.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace App\Version;
+
+use Composer\Pcre\Preg;
+
+/**
+ * Centralized definition of the Composer release channels exposed in
+ * web/versions, including their maintenance metadata.
+ *
+ * This is the single source of truth for the lts / maintenance /
+ * maintenance-until flags: it both generates the web/versions JSON (via
+ * bin/generate-versions.php) and drives the maintenance policy section of the
+ * download page (via HomeController::download()).
+ */
+class Versions
+{
+    /**
+     * Minimum PHP version per release line, in Composer's numeric encoding
+     * (e.g. 70205 = 7.2.5). Named after the PHP version so they stay meaningful
+     * as new Composer lines are added.
+     */
+    private const MIN_PHP_5_3_0 = 50300;
+    private const MIN_PHP_7_2_5 = 70205;
+
+    /**
+     * Per-line LTS metadata, keyed by the "major.minor" line. Multiple LTS lines
+     * can be maintained in parallel: add a key here (and resolve its latest
+     * version in update.sh) to introduce another one, e.g. '2.11' or '3.0'.
+     *
+     * @var array<string, array{min-php: int, maintenance: MaintenanceStatus, maintenance-until: string}>
+     */
+    private const LTS_LINES = [
+        '2.2' => [
+            'min-php' => self::MIN_PHP_5_3_0,
+            'maintenance' => MaintenanceStatus::CriticalSecurity,
+            'maintenance-until' => '2026-12-31',
+        ],
+    ];
+
+    /**
+     * Build the full web/versions structure from the version numbers resolved
+     * by update.sh. `lts` is a list of the latest version of each maintained
+     * LTS line (e.g. ['2.2.28'] today, ['2.11.5', '2.2.28'] once two LTS lines
+     * coexist).
+     *
+     * @param array{stable: string, v1: string, lts: list<string>, preview: string, v2: string, v2Path: string, snapshot: string} $resolved
+     *
+     * @return array<array-key, list<array{path: string, version: string, min-php: int, lts: bool, maintenance: string, maintenance-until: string|null}>>
+     */
+    public static function generate(array $resolved): array
+    {
+        /** @var list<array{path: string, version: string, min-php: int, lts: bool, maintenance: string, maintenance-until: string|null}> $ltsEntries */
+        $ltsEntries = [];
+        /** @var array<string, list<array{path: string, version: string, min-php: int, lts: bool, maintenance: string, maintenance-until: string|null}>> $ltsChannels */
+        $ltsChannels = [];
+        foreach ($resolved['lts'] as $version) {
+            $line = self::lineKey($version);
+            if (!isset(self::LTS_LINES[$line])) {
+                throw new \InvalidArgumentException(
+                    "No LTS metadata defined for line $line (version $version). Add it to ".self::class."::LTS_LINES."
+                );
+            }
+            $meta = self::LTS_LINES[$line];
+            $entry = self::entry(
+                '/download/'.$version.'/composer.phar',
+                $version,
+                $meta['min-php'],
+                true,
+                $meta['maintenance'],
+                $meta['maintenance-until'],
+            );
+            $ltsEntries[] = $entry;
+            $ltsChannels[$line] = [$entry];
+        }
+
+        // Active releases are maintained until at least the next feature release;
+        // this rolling minimum should be bumped whenever a new feature release ships.
+        $stable = self::activeEntry('/download/'.$resolved['stable'].'/composer.phar', $resolved['stable']);
+        $preview = self::activeEntry('/download/'.$resolved['preview'].'/composer.phar', $resolved['preview']);
+        $snapshot = self::activeEntry('/composer.phar', $resolved['snapshot']);
+        $v2 = self::activeEntry($resolved['v2Path'], $resolved['v2']);
+
+        $v1 = self::entry(
+            '/download/'.$resolved['v1'].'/composer.phar',
+            $resolved['v1'],
+            self::MIN_PHP_5_3_0,
+            false,
+            MaintenanceStatus::Eol,
+            '2026-06-30',
+        );
+
+        return [
+            'stable' => [$stable, ...$ltsEntries],
+            'preview' => [$preview, ...$ltsEntries],
+            'snapshot' => [$snapshot, ...$ltsEntries],
+            ...$ltsChannels,
+            '2' => [$v2, ...$ltsEntries],
+            '1' => [$v1],
+        ];
+    }
+
+    /**
+     * Derive the rows shown in the download page's maintenance policy section
+     * from loaded version data, so the page never hardcodes which line is LTS.
+     * One row per distinct release line, newest first. Snapshot/dev entries are
+     * skipped (their "version" is a commit hash, not a release line).
+     *
+     * @param array<string, array<int, array{path: string, version: string, min-php: int, lts: bool, maintenance: string, maintenance-until: string|null}>> $versionData
+     *
+     * @return list<array{line: string, lts: bool, status: MaintenanceStatus, until: string|null}>
+     */
+    public static function policyRows(array $versionData): array
+    {
+        $byLine = [];
+        foreach ($versionData as $entries) {
+            foreach ($entries as $entry) {
+                if (!Preg::isMatch('{^\d+\.\d+\.}', $entry['version'])) {
+                    continue;
+                }
+                $line = self::lineKey($entry['version']);
+                $byLine[$line] = [
+                    'line' => $line.'.x',
+                    'lts' => $entry['lts'],
+                    'status' => MaintenanceStatus::from($entry['maintenance']),
+                    'until' => $entry['maintenance-until'],
+                ];
+            }
+        }
+
+        uksort($byLine, fn (string $a, string $b): int => version_compare($b, $a));
+
+        return array_values($byLine);
+    }
+
+    /**
+     * @return array{path: string, version: string, min-php: int, lts: bool, maintenance: string, maintenance-until: string|null}
+     */
+    private static function activeEntry(string $path, string $version): array
+    {
+        return self::entry($path, $version, self::MIN_PHP_7_2_5, false, MaintenanceStatus::Bugfix, null);
+    }
+
+    /**
+     * @return array{path: string, version: string, min-php: int, lts: bool, maintenance: string, maintenance-until: string|null}
+     */
+    private static function entry(string $path, string $version, int $minPhp, bool $lts, MaintenanceStatus $maintenance, ?string $until): array
+    {
+        return [
+            'path' => $path,
+            'version' => $version,
+            'min-php' => $minPhp,
+            'lts' => $lts,
+            'maintenance' => $maintenance->value,
+            'maintenance-until' => $until,
+        ];
+    }
+
+    /**
+     * Reduce a version like "2.2.28" to its "major.minor" line key "2.2". Falls
+     * back to the raw string when it does not look like a release version.
+     */
+    private static function lineKey(string $version): string
+    {
+        if (Preg::isMatchStrictGroups('{^(\d+\.\d+)\.}', $version, $matches)) {
+            return $matches[1];
+        }
+
+        return $version;
+    }
+}

--- a/templates/download.html.twig
+++ b/templates/download.html.twig
@@ -102,8 +102,24 @@ php -r "unlink('composer-setup.php');"</pre>
         you can use <code>--2.2</code>.</p>
 
     <h2 id="maintenance-policy">Maintenance policy</h2>
-    <p>Bug fixes are only guaranteed to be provided for the latest feature release.</p>
-    <p>Critical bug and security fixes are also provided for active LTS releases (currently <code>2.2</code>).</p>
+    <p>Bug fixes are only guaranteed to be provided for the latest feature release.
+        Long-term support (LTS) releases additionally receive security fixes for an
+        extended period. The <code>maintenance-until</code> dates below are a minimum
+        guarantee, not a hard cutoff.</p>
+    <table aria-label="Composer maintenance status by release line" role="table">
+        <tr role="row">
+            <th role="columnheader">Release line</th>
+            <th role="columnheader">Status</th>
+            <th role="columnheader">Maintained until (minimum)</th>
+        </tr>
+        {% for row in maintenancePolicy %}
+            <tr role="row">
+                <td role="cell"><code>{{ row.line }}</code>{% if row.lts %} <strong>(LTS)</strong>{% endif %}</td>
+                <td role="cell" title="{{ row.status.description }}">{{ row.status.label }}</td>
+                <td role="cell">{{ row.until|default('Next minor release') }}</td>
+            </tr>
+        {% endfor %}
+    </table>
 
     <h2 id="manual-download">Manual Download</h2>
     <p>If you prefer to download the phar manually, here are the available versions:</p>

--- a/update.sh
+++ b/update.sh
@@ -136,18 +136,12 @@ else
     lastStableV2Version=$(ls "$root/$target/download" | grep -E '^2\.([3-9]|[0-9]{2})\.[0-9]+$' | xargs -I@ git log --format=format:"%ai @%n" -1 @ | sort -r | head -1 | awk '{print $4}')
     lastStableV2VersionPath="/download/$lastStableV2Version/composer.phar"
 fi
-{
-    # TODO add "eol":true to a version to mark eol releases and warn users
-    read -r -d '' versions << EOM
-{
-    "stable": [{"path": "/download/$lastStableVersion/composer.phar", "version": "$lastStableVersion", "min-php": 70205},{"path": "/download/$lastStableV22Version/composer.phar", "version": "$lastStableV22Version", "min-php": 50300}],
-    "preview": [{"path": "/download/$lastV2Version/composer.phar", "version": "$lastV2Version", "min-php": 70205},{"path": "/download/$lastStableV22Version/composer.phar", "version": "$lastStableV22Version", "min-php": 50300}],
-    "snapshot": [{"path": "/composer.phar", "version": "$lastSnapshot", "min-php": 70205},{"path": "/download/$lastStableV22Version/composer.phar", "version": "$lastStableV22Version", "min-php": 50300}],
-    "1": [{"path": "/download/$lastStableV1Version/composer.phar", "version": "$lastStableV1Version", "min-php": 50300}],
-    "2": [{"path": "$lastStableV2VersionPath", "version": "$lastStableV2Version", "min-php": 70205},{"path": "/download/$lastStableV22Version/composer.phar", "version": "$lastStableV22Version", "min-php": 50300}],
-    "2.2": [{"path": "/download/$lastStableV22Version/composer.phar", "version": "$lastStableV22Version", "min-php": 50300}]
-}
-EOM
-} || true
-echo "$versions" > "$root/$target/versions_new" && mv "$root/$target/versions_new" "$root/$target/versions"
+
+# web/versions is generated from a single source of truth in src/Version/Versions.php.
+# Each maintained LTS line is passed as its own *_lts argument (add more as needed).
+php "$root/bin/generate-versions.php" \
+    "stable=$lastStableVersion" "v1=$lastStableV1Version" "v2_2_lts=$lastStableV22Version" \
+    "preview=$lastV2Version" "v2=$lastStableV2Version" "v2Path=$lastStableV2VersionPath" \
+    "snapshot=$lastSnapshot" \
+    > "$root/$target/versions_new" && mv "$root/$target/versions_new" "$root/$target/versions"
 rm -f "$root/$target/stable"


### PR DESCRIPTION
This adds that to the download page:

<img width="1558" height="440" alt="image" src="https://github.com/user-attachments/assets/20cefd4e-ea88-4110-9baa-0c28a1ff696f" />

And updates the /versions file to look like this:

```json
{
    "stable": [
        {
            "path": "/download/2.10.0/composer.phar",
            "version": "2.10.0",
            "min-php": 70205,
            "lts": false,
            "maintenance": "bugfix",
            "maintenance-until": null
        },
        {
            "path": "/download/2.2.28/composer.phar",
            "version": "2.2.28",
            "min-php": 50300,
            "lts": true,
            "maintenance": "critical-security",
            "maintenance-until": "2026-12-31"
        }
    ],
    "preview": [
        {
            "path": "/download/2.10.0/composer.phar",
            "version": "2.10.0",
            "min-php": 70205,
            "lts": false,
            "maintenance": "bugfix",
            "maintenance-until": null
        },
        {
            "path": "/download/2.2.28/composer.phar",
            "version": "2.2.28",
            "min-php": 50300,
            "lts": true,
            "maintenance": "critical-security",
            "maintenance-until": "2026-12-31"
        }
    ],
    "snapshot": [
        {
            "path": "/composer.phar",
            "version": "03299ff075236be27be356498d6c64def973fe41",
            "min-php": 70205,
            "lts": false,
            "maintenance": "bugfix",
            "maintenance-until": null
        },
        {
            "path": "/download/2.2.28/composer.phar",
            "version": "2.2.28",
            "min-php": 50300,
            "lts": true,
            "maintenance": "critical-security",
            "maintenance-until": "2026-12-31"
        }
    ],
    "1": [
        {
            "path": "/download/1.10.28/composer.phar",
            "version": "1.10.28",
            "min-php": 50300,
            "lts": false,
            "maintenance": "eol",
            "maintenance-until": "2026-06-30"
        }
    ],
    "2": [
        {
            "path": "/download/2.10.0/composer.phar",
            "version": "2.10.0",
            "min-php": 70205,
            "lts": false,
            "maintenance": "bugfix",
            "maintenance-until": null
        },
        {
            "path": "/download/2.2.28/composer.phar",
            "version": "2.2.28",
            "min-php": 50300,
            "lts": true,
            "maintenance": "critical-security",
            "maintenance-until": "2026-12-31"
        }
    ],
    "2.2": [
        {
            "path": "/download/2.2.28/composer.phar",
            "version": "2.2.28",
            "min-php": 50300,
            "lts": true,
            "maintenance": "critical-security",
            "maintenance-until": "2026-12-31"
        }
    ]
}
```